### PR TITLE
Feature/uncertainties of fit parameters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       options:                  --security-opt seccomp=unconfined
     steps:
       - name:                   Checkout repository
-        uses:                   actions/checkout@v2
+        uses:                   actions/checkout@v3
 
       - name:                   Generate code coverage
         run: |

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -14,7 +14,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -30,7 +30,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,24 +1,44 @@
 # Changes for `varpro`
 
-This is the changelog for the `varpro` library. See also here for a [version history](https://crates.io/crates/varpro/versions).
+This is the changelog for the `varpro` library.
+See also here for a [version history](https://crates.io/crates/varpro/versions).
 
-## 0.6.0
+## 0.7.0 Fit Statistics
+
+- Deprecate the `minimize` function of the LevMarSolver and
+replace it with `fit`, with a slightly different API.
+- Add a function `fit_with_statistics` and a `statistics` module
+that calculates additional statistical information about the fit 
+(if successful). It allows us to extract the estimated standard
+errors of the model parameters (both linear and nonlinear) but also
+provides more complete information like the covariance matrix and
+the correlation matrix.
+- add more exhaustive tests 
+- add original varpro matlab code from DP O'Leary and BW Rust
+with permission
+- bump benchmarking dependencies
+
+## 0.6.0 Performance Improvements and Benchmarking
+
 - Add benchtests
 - Change solver API to depend on separable model trait instead of concrete impl,
 which allows us to optimize our models for performance
 - changes in model builder api, see documentation for new usage
 
-## 0.5.0
+## 0.5.0 nalgebra Update
+
 - Upgrade nalgebra and levenberg_marquardt dependencies to current versions
 - Fix deprecation warnings and expand test coverage slightly
 
-## 0.4.1
+## 0.4.1 Misc Maintanance
+
 - Remove snafu dependency and replace by `thiserror`
 - Use uninitialized matrices instead of zero initialisation for places where contents will be overwritten anyways
 - Fix new clippy lints
 - Redo the code coverage workflow and switch to coveralls from codecov
 
 ## 0.3.0, 0.4.0
+
 Upgrade dependencies
 
 
@@ -28,4 +48,5 @@ Upgrade dependencies
 - Update `nalgebra` dependency to 0.25.3
 
 ## 0.1.0
+
 Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ homepage = "https://github.com/geo-ant/varpro"
 repository = "https://github.com/geo-ant/varpro"
 description = "A straightforward nonlinear least-squares fitting library which uses the Variable Projection algorithm."
 readme = "README.md"
-categories = ["mathematics","science","algorithms"]
-keywords = ["nonlinear","least","squares","fitting","regression"]
+categories = ["mathematics", "science", "algorithms"]
+keywords = ["nonlinear", "least", "squares", "fitting", "regression"]
 
 [workspace]
-members  = [ "shared_test_code" ]
+members = ["shared_test_code"]
 
 [dependencies]
 thiserror = "1"
@@ -23,9 +23,9 @@ num-traits = "0.2"
 [dev-dependencies]
 approx = "0.5"
 num-complex = "0.4"
-criterion = "0.4"
-pprof = {version = "0.11",features = ["criterion","flamegraph"]}
-shared_test_code = {path = "./shared_test_code"}
+criterion = "0.5"
+pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
+shared_test_code = { path = "./shared_test_code" }
 assert_matches = "1.5"
 mockall = "0.11"
 
@@ -36,4 +36,4 @@ harness = false
 [package.metadata.docs.rs]
 # To build locally use
 #   RUSTDOCFLAGS="--html-in-header katex-header.html" cargo doc --no-deps --open
-rustdoc-args = [ "--html-in-header", "katex-header.html" ]
+rustdoc-args = ["--html-in-header", "katex-header.html"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/geo-ant/varpro"
 description = "A straightforward nonlinear least-squares fitting library which uses the Variable Projection algorithm."
 readme = "README.md"
 categories = ["mathematics", "science", "algorithms"]
-keywords = ["nonlinear", "least", "squares", "fitting", "regression"]
+keywords = ["nonlinear", "regression", "function", "fitting", "least-squares"]
 
 [workspace]
 members = ["shared_test_code"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "varpro"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["geo-ant"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -6,18 +6,21 @@
 [![Coverage Status](https://coveralls.io/repos/github/geo-ant/varpro/badge.svg?branch=main)](https://coveralls.io/github/geo-ant/varpro?branch=main)
 ![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
 
-This library provides robust and fast least-squares fitting of nonlinear,
-separable model functions to observations. It uses the VarPro algorithm to achieve this.
+Nonlinear function fitting made simple. This library provides robust and fast 
+least-squares fitting of a wide class of model functions to data.
+It uses the VarPro algorithm to achieve this, hence the name.
 
 ## Brief Introduction
 
-The lack of formulas on this site makes it hard to get into the depth of the 
-what and how of this crate at this point.
+This crate implements a powerful algorithm
+to fit model functions to data, but it is restricted to so called _separable_
+models. See the next section for an explanation. The lack of formulas on this 
+site makes it hard to get into the depth of the what and how of this crate at this point.
 [Refer to the documentation](https://docs.rs/varpro/) for all the meaty details including the math.
 
-### What are Separable Model Functions?
+### What are Separable Models?
 
-Put simply, separable model functions are nonlinear functions that can be 
+Put simply, separable models are nonlinear functions that can be 
 written as a *linear combination* of some *nonlinear* basis functions.
 A common use case for VarPro is e.g. fitting sums of exponentials,
 which is a notoriously ill-conditioned problem.
@@ -25,20 +28,21 @@ which is a notoriously ill-conditioned problem.
 ### What is VarPro?
 
 Variable Projection (VarPro) is an algorithm that takes advantage of the fact 
-that the fitting problem can be separated into linear and truly nonlinear parameters.
-The linear parameters are eliminated and the fitting problem is cast into a 
-problem that only depends on the nonlinear parameters.
+that the given fitting problem can be separated into linear and truly nonlinear parameters.
+The linear parameters are eliminated using some clever linear algebra
+and the fitting problem is cast into a problem that only depends on the nonlinear parameters.
 This reduced problem is then solved by using a common nonlinear fitting algorithm,
 such as Levenberg-Marquardt (LM).
 
 ### When Should You Give it a Try?
 
 VarPro can dramatically increase the robustness and speed of the fitting process
-compared to using the nonlinear exclusively. When
-* the model function you want to fit is a linear combination of nonlinear functions
-* *and* you know the analytical derivatives of all those functions
+compared to using a "normal" nonlinear least squares fitting algorithm. When
 
-*then* you should give it a whirl.
+* the model function you want to fit is a linear combination of nonlinear functions
+* _and_ you know the analytical derivatives of all those functions
+
+_then_ you should give it a whirl.
 
 ## Example Usage
 
@@ -97,14 +101,14 @@ For more examples please refer to the crate documentation.
 
 ### Maximum Performance
 
-While the example code above should already run many times faster
-than an equivalent implementation using just a nonlinear solver
-without the magic of varpro, this crate offers a way of 
-squeezing out the last bits of performance.
-The `SeparableNonlinearModel` can be manually
-implemented to shave of the last hundreds of microseconds
-from the computation. The crate documentation contains detailed
-examples.
+The example code above will already run many times faster
+than just using a nonlinear solver without the magic of varpro.
+But this crate offers an additional way to eek out the last bits of  performance.
+
+The `SeparableNonlinearModel` trait can be manually
+implemented to describe a model function. This often allows us to shave of the 
+last hundreds of microseconds from the computation e.g. by caching intermediate
+calculations. The crate documentation contains detailed examples.
 
 ## References and Further Reading
 

--- a/README.md
+++ b/README.md
@@ -89,15 +89,22 @@ let problem = LevMarProblemBuilder::new(model)
   .build()
   .unwrap();
 // 3. Solve the fitting problem
-let (solved_problem, report) = LevMarSolver::new().minimize(problem);
-assert!(report.termination.was_successful());
+let fit_result = LevMarSolver::new()
+    .fit(problem)
+    .expect("fit must exit successfully");
 // 4. obtain the nonlinear parameters after fitting
-let alpha = solved_problem.params();
+let alpha = fit_result.nonlinear_parameters();
 // 5. obtain the linear parameters
-let c = solved_problem.linear_coefficients().unwrap();
+let c = fit_result.linear_coefficients().unwrap();
 ```
 
 For more examples please refer to the crate documentation.
+
+### Fit Statistics
+
+Additionally to the `fit` member function, the `LevMarSolver` also provides a 
+`fit_with_statistics` function that calculations some additional statistical
+information after the fit has finished.
 
 ### Maximum Performance
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ implemented to describe a model function. This often allows us to shave of the
 last hundreds of microseconds from the computation e.g. by caching intermediate
 calculations. The crate documentation contains detailed examples.
 
+## Acknowledgements
+
+I am grateful to Professor [Dianne P. O'Leary](http://www.cs.umd.edu/~oleary/)
+and [Bert W. Rust &#10013;](https://math.nist.gov/~BRust/) who published the paper that 
+enabled me to understand varpro and come up with this implementation.
+Professor O'Leary also graciously answered my questions on her paper and
+some implementation details.
+
 ## References and Further Reading
 
 (O'Leary2013) O’Leary, D.P., Rust, B.W. Variable projection for nonlinear least squares problems.

--- a/benches/double_exponential_without_noise.rs
+++ b/benches/double_exponential_without_noise.rs
@@ -118,13 +118,11 @@ where
 fn run_minimization_for_handrolled_separable_model(
     problem: LevMarProblem<DoubleExpModelWithConstantOffsetSepModel>,
 ) -> [f64; 5] {
-    let (problem, report) = LevMarSolver::new().minimize(problem);
-    assert!(
-        report.termination.was_successful(),
-        "Termination not successful"
-    );
-    let params = problem.params();
-    let coeff = problem.linear_coefficients().unwrap();
+    let result = LevMarSolver::new()
+        .fit(problem)
+        .expect("fitting must exit successfully");
+    let params = result.nonlinear_parameters();
+    let coeff = result.linear_coefficients().unwrap();
     [params[0], params[1], coeff[0], coeff[1], coeff[2]]
 }
 
@@ -134,13 +132,11 @@ fn run_minimization_for_handrolled_separable_model(
 fn run_minimization_for_builder_separable_model(
     problem: LevMarProblem<SeparableModel<f64>>,
 ) -> [f64; 5] {
-    let (problem, report) = LevMarSolver::new().minimize(problem);
-    assert!(
-        report.termination.was_successful(),
-        "Termination not successful"
-    );
-    let params = problem.params();
-    let coeff = problem.linear_coefficients().unwrap();
+    let result = LevMarSolver::new()
+        .fit(problem)
+        .expect("fitting must exit successfully");
+    let params = result.nonlinear_parameters();
+    let coeff = result.linear_coefficients().unwrap();
     [params[0], params[1], coeff[0], coeff[1], coeff[2]]
 }
 

--- a/benches/double_exponential_without_noise.rs
+++ b/benches/double_exponential_without_noise.rs
@@ -1,5 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use levenberg_marquardt::LeastSquaresProblem;
+use levenberg_marquardt::LevenbergMarquardt;
 use nalgebra::ComplexField;
 
 use nalgebra::Const;
@@ -148,7 +149,7 @@ fn run_minimization_for_builder_separable_model(
 fn run_minimization_for_levenberg_marquardt_crate_problem(
     problem: DoubleExponentialDecayFittingWithOffsetLevmar,
 ) -> [f64; 5] {
-    let (problem, report) = LevMarSolver::new()
+    let (problem, report) = LevenbergMarquardt::new()
         // if I don't set this, the solver will not converge
         .with_stepbound(1.)
         .minimize(problem);

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -1,0 +1,10 @@
+# varpro.m
+
+This is the original matlab code published by Dianne P. O'Leary and Bert W. Rust 
+for their 2013 paper [here](https://www.cs.umd.edu/~oleary/software/varpro/).
+It contains just one modification to make it work on GNU Octave as well as Matlab. This
+modification is just a package include and will not change the original logic.
+
+## Acknowledgements
+
+This code is republished here with the permission of Professor O'Leary. Thank you.

--- a/matlab/examples/adaex.m
+++ b/matlab/examples/adaex.m
@@ -1,0 +1,43 @@
+
+function [Phi,dPhi,Ind] = adaex(alpha,t)
+
+% function [Phi,dPhi,Ind] = adaex(alpha,t)
+% This is a sample user-defined function to be used by varpro.m.
+%
+% The model for this sample problem is
+%
+%   eta(t) = c1 exp(-alpha2 t)*cos(alpha3 t) 
+%          + c2 exp(-alpha1 t)*cos(alpha2 t)
+%          = c1 Phi1 + c2 Phi2.
+%
+% Given t and alpha, we evaluate Phi, dPhi, and Ind.
+%
+% Dianne P. O'Leary and Bert W. Rust, September 2010.
+
+
+% Evaluate Phi1 = exp(-alpha2 t)*cos(alpha3 t),
+%          Phi2 = exp(-alpha1 t)*cos(alpha2 t),
+% at each of the data points in t.
+
+    Phi(:,1) = exp(-alpha(2)*t).*cos(alpha(3)*t);
+    Phi(:,2) = exp(-alpha(1)*t).*cos(alpha(2)*t);
+
+% The nonzero partial derivatives of Phi with respect to alpha are
+%              d Phi_1 / d alpha_2 ,
+%              d Phi_1 / d alpha_3 ,
+%              d Phi_2 / d alpha_1 ,
+%              d Phi_2 / d alpha_2 ,
+% and this determines Ind.
+% The ordering of the columns of Ind is arbitrary but must match dPhi.
+
+    Ind = [1 1 2 2
+           2 3 1 2];
+
+% Evaluate the four nonzero partial derivatives of Phi at each of 
+% the data points and store them in dPhi.
+
+    dPhi(:,1) = -t .* Phi(:,1);
+    dPhi(:,2) = -t .* exp(-alpha(2)*t).*sin(alpha(3)*t);
+    dPhi(:,3) = -t .* Phi(:,2);
+    dPhi(:,4) = -t .* exp(-alpha(1)*t).*sin(alpha(2)*t);
+

--- a/matlab/examples/varpro_example.m
+++ b/matlab/examples/varpro_example.m
@@ -1,0 +1,67 @@
+% varpro_example.m
+% Sample problem illustrating the use of varpro.m
+%
+% Observations y(t) are given at 10 values of t.
+%
+% The model for this function y(t) is 
+%
+%   eta(t) = c1 exp(-alpha2 t)*cos(alpha3 t) 
+%          + c2 exp(-alpha1 t)*cos(alpha2 t)
+%
+% The linear parameters are c1 and c2, and the 
+%  nonlinear parameters are alpha1, alpha2, and alpha3.
+%
+% The two nonlinear functions in the model are
+%
+%   Phi1(alpha,t) = exp(-alpha2 t)*cos(alpha3 t),
+%   Phi2(alpha,t) = exp(-alpha1 t)*cos(alpha2 t).
+%
+% Dianne P. O'Leary and Bert W. Rust, September 2010
+
+disp('****************************************')
+disp('Sample problem illustrating the use of varpro.m')
+
+% Data observations y(t) were taken at these times:
+
+t = [0;.1;.22;.31;.46;.50;.63;.78;.85;.97];
+
+y = [ 6.9842;  5.1851;  2.8907;  1.4199; -0.2473; 
+     -0.5243; -1.0156; -1.0260; -0.9165; -0.6805];
+
+% The weights for the least squares fit are stored in w.
+
+w = [ 1.0; 1.0; 1.0; 0.5; 0.5; 1.0; 0.5; 1.0; 0.5; 0.5];       
+
+% Set varpro options to display the progress of the iteration
+% and to check the correctness of the derivative formulas.
+
+options = optimset('Display','iter','DerivativeCheck','on');
+
+% Set the initial guess for alpha and call varpro to estimate
+% alpha and c.
+
+alphainit = [0.5; 2; 3];  % initial guess
+
+tic
+[alpha,c,wresid,resid_norm,y_est,Regression] = ...
+     varpro(y,w,alphainit,2,@(alpha)adaex(alpha,t),[],[],options);
+toc
+
+% The data y(t) were generated using the parameters 
+%         alphatrue = [1.0; 2.5; 4.0], ctrue = [6; 1].  
+% Noise was added to the data, so these parameters do not provide
+% the best fit.  The computed solution is:
+%    Linear Parameters:
+%      5.8416357e+00    1.1436854e+00 
+%    Nonlinear Parameters:
+%      1.0132255e+00    2.4968675e+00    4.0625148e+00 
+% Note that there are many sets of parameters that fit the data well.
+
+% Display some regression diagnostics.
+
+Regression
+disp('Correlation matrix')
+disp(Regression.CorMx)
+
+disp('End of sample problem.')
+disp('****************************************')

--- a/matlab/varpro.m
+++ b/matlab/varpro.m
@@ -1,0 +1,745 @@
+function [alpha, c, wresid, wresid_norm, y_est, Regression] = ...
+          varpro(y, w, alpha, n, ada, lb, ub, options)
+%VARPRO Solve a separable nonlinear least squares problem.
+% [alpha, c, wresid, wresid_norm, y_est, Regression] =
+%             VARPRO(y, w, alpha, n, ada, lb, ub, options)
+%
+% Given a set of m observations y(1),...,y(m)
+% this program computes a weighted least squares fit using the model
+%
+%    eta(alpha,c,t) = 
+%            c_1 * phi_1 (alpha,t) + ...  + c_n * phi_n (alpha,t) 
+% (possibly with an extra term  + phi_{n+1} (alpha,t) ).
+%
+% This program determines optimal values of the q nonlinear parameters
+% alpha and the n linear parameters c, given observations y at m
+% different values of the "time" t and given evaluation of phi and 
+% (optionally) derivatives of phi.
+%
+% On Input:
+%
+%   y    m x 1   vector containing the m observations.
+%   w    m x 1   vector of weights used in the least squares
+%                fit.  We minimize the norm of the weighted residual
+%                vector r, where, for i=1:m,
+%
+%                r(i) = w(i) * (y(i) - eta(alpha, c, t(i,:))).
+%
+%                Therefore, w(i) should be set to 1 divided by
+%                the standard deviation in the measurement y(i).  
+%                If this number is unknown, set w(i) = 1.
+%   alpha q x 1  initial estimates of the parameters alpha.
+%                If alpha = [], Varpro assumes that the problem
+%                is linear and returns estimates of the c parameters.
+%   n            number of linear parameters c
+%   ada          a function handle, described below.
+%   lb    q x 1  lower bounds on the parameters alpha. 
+%   (Optional)   (Omit this argument or use [] if there are
+%                no lower bounds.)
+%   ub    q x 1  upper bounds on the parameters alpha. 
+%   (Optional)   (Omit this argument or use [] if there are
+%                no upper bounds.)
+%   options      The Matlab optimization parameter structure,
+%   (Optional)   set by "optimset", to control convergence
+%                tolerances, maximum number of function evaluations,
+%                information displayed in the command window, etc. 
+%                To use default options, omit this parameter.
+%                To determine the default options, type
+%                    options = optimset('lsqnonlin')
+%                After doing this, the defaults can be modified;
+%                to modify the display option, for example, type
+%                    options = optimset('lsqnonlin');
+%                    optimset(options,'Display','iter');
+%
+% On Output:
+%
+%  alpha  q x 1  estimates of the nonlinear parameters.
+%  c      n x 1  estimates of the linear parameters.
+%  wresid m x 1  weighted residual vector, with i-th component
+%                w(i) * (y(i) - eta(alpha, c, t(i,:))).
+%  wresid_norm   norm of wresid.
+%  y_est  m x 1  the model estimates = eta(alpha, c, t(i,:)))
+%  Regression    a structure containing diagnostics about the model fit.
+%                **************************************************
+%                *                C a u t i o n:                  *
+%                *   The theory that makes statistical            *
+%                *   diagnostics useful is derived for            *
+%                *   linear regression, with no upper- or         *
+%                *   lower-bounds on variables.                   *
+%                *   The relevance of these quantities to our     *
+%                *   nonlinear model is determined by how well    *
+%                *   the linearized model (Taylor series model)   *
+%                *         eta(alpha_true, c_true)                *
+%                *            +  Phi * (c  - c_true)              *
+%                *            + dPhi * (alpha - alpha_true)       *
+%                *   fits the data in the neighborhood of the     *
+%                *   true values for alpha and c, where Phi       *
+%                *   and dPhi contain the partial derivatives     *
+%                *   of the model with respect to the c and       *
+%                *   alpha parameters, respectively, and are      *
+%                *   defined in ada.                              *
+%                **************************************************
+%  Regression.report:  
+%                This structure includes information on the solution
+%                process, including the number of iterations, 
+%                termination criterion, and exitflag from lsqnonlin.
+%                (Type 'help lsqnonlin' to see the exit conditions.)
+%                Regression.report.rank is the computed rank of the 
+%                matrix for the linear subproblem.  If this equals
+%                n, then the linear coefficients are well-determined.
+%                If it is less than n, then although the model might
+%                fit the data well, other linear coefficients might
+%                give just as good a fit.
+%  Regression.sigma:        
+%                The estimate of the standard deviation is the
+%                weighted residual norm divided by the square root
+%                of the number of degrees of freedom.
+%                This is also called the "regression standard error"
+%                or the square-root of the weighted SSR (sum squared
+%                residual) divided by the square root of the
+%                number of degrees of freedom.
+%  Regression.RMS:
+%                The "residual mean square" is equal to sigma^2:
+%                RMS = wresid_norm^2 / (m-n+q)
+%  Regression.coef_determ:
+%                The "coefficient of determination" for the fit,
+%                also called the square of the multiple correlation
+%                coefficient, is sometimes called R^2.
+%                It is computed as 1 - wresid_norm^2/CTSS,
+%                where the "corrected total sum of squares"
+%                CTSS is the norm-squared of W*(y-y_bar),
+%                and the entries of y_bar are all equal to
+%                (the sum of W_i^2 y_i) divided by (the sum of W_i^2).
+%                A value of .95, for example, indicates that 95 per 
+%                cent of the CTTS is accounted for by the fit.
+%
+%  Regression.CovMx: (n+q) x (n+q)
+%                This is the estimated variance/covariance matrix for
+%                the parameters.  The linear parameters c are ordered
+%                first, followed by the nonlinear parameters alpha.
+%                This is empty if dPhi is not computed by ada.
+%  Regression.CorMx: (n+q) x (n+q)
+%                This is the estimated correlation matrix for the 
+%                parameters.  The linear parameters c are ordered
+%                first, followed by the nonlinear parameters alpha.
+%                This is empty if dPhi is not computed by ada.
+%  Regression.std_param: (n+q) x 1
+%                This vector contains the estimate of the standard 
+%                deviation for each parameter.
+%                The k-th element is the square root of the k-th main 
+%                diagonal element of Regression.CovMx
+%                This is empty if dPhi is not computed by ada.
+%  Regression.t_ratio:   (n+q) x 1
+%                The t-ratio for each parameter is equal to the
+%                parameter estimate divided by its standard deviation.
+%                (linear parameters c first, followed by alpha)
+%                This is empty if dPhi is not computed by ada.
+%  Regression.standardized_wresid:
+%                The k-th component of the "standardized weighted 
+%                residual" is the k-th component of the weighted 
+%                residual divided by its standard deviation.
+%                This is empty if dPhi is not computed by ada.
+%
+%---------------------------------------------------------------
+% Specification of the function ada, which computes information
+% related to Phi:
+%
+%   function [Phi,dPhi,Ind] = ada(alpha)
+%
+%     This function computes Phi and, if possible, dPhi.
+%
+%     On Input: 
+%
+%        alpha q x 1    contains the current value of the alpha parameters.
+%
+%        Note:  If more input arguments are needed, use the standard
+%               Matlab syntax to accomplish this.  For example, if
+%               the input arguments to ada are t, z, and alpha, then
+%               before calling varpro, initialize t and z, and in calling 
+%               varpro, replace "@ada" by "@(alpha)ada(t,z,alpha)".
+%
+%     On Output:
+%
+%        Phi   m x n1   where Phi(i,j) = phi_j(alpha,t_i).
+%                       (n1 = n if there is no extra term; 
+%                        n1 = n+1 if an extra term is used)
+%        dPhi  m x p    where the columns contain partial derivative
+%                       information for Phi and p is the number of 
+%                       columns in Ind 
+%                       (or dPhi = [] if derivatives are not available).
+%        Ind   2 x p    Column k of dPhi contains the partial
+%                       derivative of Phi_j with respect to alpha_i, 
+%                       evaluated at the current value of alpha, 
+%                       where j = Ind(1,k) and i = Ind(2,k).
+%                       Columns of dPhi that are always zero, independent
+%                       of alpha, need not be stored. 
+%        Example:  if  phi_1 is a function of alpha_2 and alpha_3, 
+%                  and phi_2 is a function of alpha_1 and alpha_2, then 
+%                  we can set
+%                          Ind = [ 1 1 2 2
+%                                  2 3 1 2 ]
+%                  In this case, the p=4 columns of dPhi contain
+%                          d phi_1 / d alpha_2,
+%                          d phi_1 / d alpha_3,
+%                          d phi_2 / d alpha_1,
+%                          d phi_2 / d alpha_2,
+%                  evaluated at each t_i.
+%                  There are no restrictions on how the columns of
+%                  dPhi are ordered, as long as Ind correctly specifies
+%                  the ordering.
+%
+%        If derivatives dPhi are not available, then set dPhi = Ind = [].
+%      
+%---------------------------------------------------------------
+%
+%  Varpro calls lsqnonlin, which solves a constrained least squares
+%  problem with upper and lower bounds on the constraints.  What
+%  distinguishes varpro from lsqnonlin is that, for efficiency and
+%  reliability, varpro causes lsqnonlin to only iterate on the
+%  nonlinear parameters.  Given the information in Phi and dPhi, this 
+%  requires an intricate but inexpensive computation of partial 
+%  derivatives, and this is handled by the varpro function formJacobian.
+%
+%  lsqnonlin is in Matlab's Optimization Toolbox.  Another solver
+%  can be substituted if the toolbox is not available.
+%
+%  Any parameters that require upper or lower bounds should be put in
+%  alpha, not c, even if they appear linearly in the model.
+%  
+%  The original Fortran implementation of the variable projection 
+%  algorithm (ref. 2) was modified in 1977 by John Bolstad 
+%  Computer Science Department, Serra House, Stanford University,
+%  using ideas of Linda Kaufman (ref. 5) to speed up the 
+%  computation of derivatives.  He also allowed weights on
+%  the observations, and computed the covariance matrix.
+%  Our Matlab version takes advantage of 30 years of improvements
+%  in programming languages and minimization algorithms.  
+%  In this version, we also allow upper and lower bounds on the 
+%  nonlinear parameters.
+%
+%  It is hoped that this implementation will be of use to Matlab
+%  users, but also that its simplicity will make it easier for the
+%  algorithm to be implemented in other languages.
+%
+%  This program is documented in
+%  Dianne P. O'Leary and Bert W. Rust,
+%  Variable Projection for Nonlinear Least Squares Problems,
+%  US National Inst. of Standards and Technology, 2010.
+%
+%  Main reference:
+%
+%    0.  Gene H. Golub and V. Pereyra, 'Separable nonlinear least   
+%        squares: the variable projection method and its applications,'
+%        Inverse Problems 19, R1-R26 (2003).
+%         
+%  See also these papers, cited in John Bolstad's Fortran code:
+%                                                                       
+%    1.  Gene H. Golub and V. Pereyra, 'The differentiation of      
+%        pseudo-inverses and nonlinear least squares problems whose 
+%        variables separate,' SIAM J. Numer. Anal. 10, 413-432      
+%         (1973).                                                    
+%    2.  ------, same title, Stanford C.S. Report 72-261, Feb. 1972.
+%    3.  Michael R. Osborne, 'Some aspects of non-linear least      
+%        squares calculations,' in Lootsma, Ed., 'Numerical Methods 
+%        for Non-Linear Optimization,' Academic Press, London, 1972.
+%    4.  Fred Krogh, 'Efficient implementation of a variable projection
+%        algorithm for nonlinear least squares problems,'           
+%        Comm. ACM 17:3, 167-169 (March, 1974).                    
+%    5.  Linda Kaufman, 'A variable projection method for solving  
+%        separable nonlinear least squares problems', B.I.T. 15,   
+%        49-57 (1975).                                             
+%    6.  C. Lawson and R. Hanson, Solving Least Squares Problems,
+%        Prentice-Hall, Englewood Cliffs, N. J., 1974.          
+%
+%  These books discuss the statistical background:
+%
+%    7.  David A. Belsley, Edwin Kuh, and Roy E. Welsch, Regression 
+%        Diagnostics, John Wiley & Sons, New York, 1980, Chap. 2.
+%    8.  G.A.F. Seber and C.J. Wild, Nonlinear Regression,
+%        John Wiley & Sons, New York, 1989, Sec. 2.1, 5.1, and 5.2.
+%
+%  Dianne P. O'Leary, NIST and University of Maryland, February 2011.
+%  Bert W. Rust,      NIST                             February 2011.
+%  Comments updated 07-2011.
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+global mydebug myneglect   % test neglect of extra term in Jacobian
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% Initialization: Check input, set default parameters and options.
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% special case for octave
+is_octave = exist('OCTAVE_VERSION', 'builtin') > 0;
+if (is_octave)
+  pkg load optim;
+end
+
+[m,ell] = size(y);      % m = number of observations
+[m1,ell1] = size(w);
+
+if (m1 ~= m) | (ell > 1) | (ell1 > 1)
+  error('y and w must be column vectors of the same length')
+end
+
+[q,ell] = size(alpha);   % q = number of nonlinear parameters
+
+if (ell > 1)
+  error('alpha must be a column vector containing initial guesses for nonlinear parameters')
+end
+
+if (nargin < 6)  
+  lb = [];
+else
+  [q1,ell] = size(lb);
+  if (q1 > 0) & (ell > 0)
+    if (q1 ~= q) | (ell > 1)
+      error('lb must be empty or a column vector of the same length as alpha')
+    end
+  end
+end
+
+if (nargin < 7)
+  ub = [];
+else
+  [q1,ell] = size(ub);
+  if (q1 > 0) & (ell > 0)
+    if (q1 ~= q) | (ell > 1)
+      error('ub must be empty or a column vector of the same length as alpha')
+    end
+  end
+end
+
+if (nargin < 8)
+  options = optimset('lsqnonlin');  
+end
+
+if (~strcmp(options.Display,'off'))
+  disp(sprintf('\n-------------------'))
+  disp(sprintf('VARPRO is beginning.'))
+end
+
+W = spdiags(w,0,m,m);  % Create an m x m diagonal matrix from the vector w
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% Make the first call to ada and do some error checking.
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+[Phi, dPhi, Ind] = feval(ada, alpha);
+
+[m1,n1] = size(Phi);     % n1 = number of basis functions Phi.
+
+[m2,n2] = size(dPhi);
+[ell,n3] = size(Ind);
+
+if (m1 ~= m2) & (m2 > 0)
+  error('In user function ada: Phi and dPhi must have the same number of rows.')
+end
+
+if (n1 < n) | (n1 > n+1)
+  error('In user function ada: The number of columns in Phi must be n or n+1.')
+end
+
+if (n2 > 0) & (ell ~= 2)
+  error('In user function ada: Ind must have two rows.')
+end
+
+if (n2 > 0) & (n2 ~= n3)
+  error('In user function ada: dPhi and Ind must have the same number of columns.')
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% Solve the least squares problem using lsqnonlin or, if there
+% are no nonlinear parameters, using the SVD procedure in formJacobian.
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+if (q > 0) % The problem is nonlinear.
+
+  if ~isempty(dPhi)
+    options = optimset(options,'Jacobian','on');
+  end
+
+  [alpha, wresid_norm2, wresid, exitflag,output] = ...
+    lsqnonlin(@f_lsq, alpha, lb, ub, options);
+  [r, Jacobian, Phi, dPhi, y_est, rank] = f_lsq(alpha);
+  wresid_norm = sqrt(wresid_norm2);
+  Regression.report = output;
+  Regression.report.rank = rank;
+  Regression.report.exitflag = exitflag;
+
+else       % The problem is linear.
+
+  if (~strcmp(options.Display,'off'))
+    disp(sprintf('VARPRO problem is linear, since length(alpha)=0.'))
+  end
+
+  [Jacobian, c, wresid, y_est, Regression.report.rank] =  ...
+    formJacobian(alpha, Phi, dPhi);
+  wresid_norm = norm(wresid);
+  wresid_norm2 = wresid_norm * wresid_norm;
+
+end % if q > 0
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%  Compute some statistical diagnostics for the solution.
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% Calculate sample variance,  the norm-squared of the residual
+%    divided by the number of degrees of freedom.
+
+sigma2 = wresid_norm2 / (m-n-q);
+
+% Compute  Regression.sigma:        
+%                square-root of weighted residual norm squared divided 
+%                by number of degrees of freedom.
+
+Regression.sigma = sqrt(sigma2);
+
+% Compute  Regression.coef_determ:
+%                The coeficient of determination for the fit,
+%                also called the square of the multiple correlation
+%                coefficient, or R^2.
+%                It is computed as 1 - wresid_norm^2/CTSS,
+%                where the "corrected total sum of squares"
+%                CTSS is the norm-squared of W*(y-y_bar),
+%                and the entries of y_bar are all equal to
+%                (the sum of W_i y_i) divided by (the sum of W_i).
+
+y_bar = sum(w.*y) / sum(w);
+CTTS = norm(W * (y - y_bar)) ^2;
+Regression.coef_determ = 1 - wresid_norm^2 / CTTS;
+
+% Compute  Regression.RMS = sigma^2:
+%                the weighted residual norm divided by the number of
+%                degrees of freedom.
+%                RMS = wresid_norm / sqrt(m-n+q)
+
+Regression.RMS = sigma2;                        
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%  Compute some additional statistical diagnostics for the 
+%  solution, if the user requested it.
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+if (nargout==6) 
+
+  if (isempty(dPhi))
+
+    Regression.CovMx = [];
+    Regression.CorMx = [];
+    Regression.std_param = [];
+    Regression.t_ratio = [];
+    Regression.standardized_wresid = [];
+
+  else
+
+    % Calculate the covariance matrix CovMx, which is sigma^2 times the
+    % inverse of H'*H, where  
+    %              H = W*[Phi,J] 
+    % contains the partial derivatives of  wresid  with
+    % respect to the parameters in alpha and c.
+
+    [xx,pp] = size(dPhi);
+    J = zeros(m,q);
+    for kk = 1:pp,
+      j = Ind(1,kk);
+      i = Ind(2,kk);
+      if (j > n)
+        J(:,i) = J(:,i) + dPhi(:,kk);
+      else
+        J(:,i) = J(:,i) + c(j) * dPhi(:,kk);
+      end
+    end
+    [Qj,Rj,Pj] = qr(W*[Phi(:,1:n),J], 0);     % Uses compact pivoted QR.
+    T2 = Rj \ (eye(size(Rj,1)));
+    CovMx = sigma2 * T2 * T2';
+    Regression.CovMx(Pj,Pj) = CovMx;  % Undo the pivoting permutation.
+
+    % Compute  Regression.CorMx:        
+    %                estimated correlation matrix (n+q) x (n+q) for the
+    %                parameters.  The linear parameters are ordered
+    %                first, followed by the nonlinear parameters.
+
+    d = 1 ./ sqrt(diag(Regression.CovMx));
+    D = spdiags(d,0,n+q,n+q);
+    Regression.CorMx = D * Regression.CovMx * D;
+
+    % Compute  Regression.std_param:
+    %                The k-th element is the square root of the k-th main 
+    %                diagonal element of CovMx. 
+
+    Regression.std_param = sqrt(diag(Regression.CovMx));
+
+    % Compute  Regression.t_ratio:
+    %                parameter estimates divided by their standard deviations.
+
+    alpha = reshape(alpha, q, 1);
+    Regression.t_ratio = [c; alpha] .* d;
+
+    % Compute  Regression.standardized_wresid:
+    %                The k-th component is the k-th component of the
+    %                weighted residual, divided by its standard deviation.
+    %                Let X = W*[Phi,J], 
+    %                    h(k) = k-th main diagonal element of covariance
+    %                           matrix for wresid
+    %                         = k-th main diagonal element of X*inv(X'*X)*X' 
+    %                         = k-th main diagonal element of Qj*Qj'.
+    %                Then the standard deviation is estimated by
+    %                sigma*sqrt(1-h(k)).
+
+    for k=1:m
+      temp(k,1) = Qj(k,:) * Qj(k,:)';
+    end
+    Regression.standardized_wresid = wresid ./(Regression.sigma*sqrt(1-temp));
+
+  end
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% End of statistical diagnostics computations.
+% Print some final information if desired.
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+if (~strcmp(options.Display,'off'))
+  disp(sprintf(' '))
+  disp(sprintf('VARPRO Results:'))
+  disp(sprintf(' Linear Parameters:'))
+  disp(sprintf(' %15.7e ',c))
+
+  disp(sprintf(' Nonlinear Parameters:'))
+  disp(sprintf(' %15.7e ',alpha))
+  disp(sprintf(' '))
+
+  disp(sprintf(' Norm-squared of weighted residual  = %15.7e',wresid_norm2))
+  disp(sprintf(' Norm-squared of data vector        = %15.7e',norm(w.*y)^2))
+  disp(sprintf(' Norm         of weighted residual  = %15.7e',wresid_norm))
+  disp(sprintf(' Norm         of data vector        = %15.7e',norm(w.*y)))
+  disp(sprintf(' Expected error of observations     = %15.7e',Regression.sigma))
+  disp(sprintf(' Coefficient of determination       = %15.7e',Regression.coef_determ))
+  disp(sprintf('VARPRO is finished.'))
+  disp(sprintf('-------------------\n'))
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% The computation is now completed.  
+%
+% varpro uses the following two functions, f_lsq and formJacobian.
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+%--------------------------- Beginning of f_lsq --------------------------
+
+  function [wr_trial, Jacobian, Phi_trial, dPhi_trial, y_est,myrank] = ...
+      f_lsq(alpha_trial)
+
+    % function [wr_trial,Jacobian,Phi_trial,dPhi_trial,y_est,myrank] = ...
+    %                                                       f_lsq(alpha_trial)
+    %
+    % This function is used by lsqnonlin to compute 
+    %          wr_trial   the current weighted residual
+    %          Jacobian   the Jacobian matrix for the nonlinear parameters
+    % It also computes
+    %          Phi_trial  the current Phi matrix
+    %          dPhi_trial the partial derivatives of Phi_trial (if available).
+    %          y_est      the model estimates of y
+    %          myrank     the rank of the matrix W*Phi in the linear problem.
+    %
+    % It uses the user-supplied function ada and the Varpro function formJacobian.
+
+    [Phi_trial, dPhi_trial, Ind] = feval(ada, alpha_trial);
+
+    [Jacobian, c, wr_trial, y_est,myrank] = ...
+      formJacobian(alpha_trial, Phi_trial, dPhi_trial);
+
+  end %--------------------------- End of f_lsq ---------------------------
+
+  %----------------------- Beginning of formJacobian ----------------------
+
+  function [Jacobian, c, wresid, y_est,myrank] = formJacobian(alpha, Phi, dPhi)
+
+    % function [Jacobian, c, wresid, y_est,myrank] =  formJacobian(alpha, Phi, dPhi)
+    %
+    % This function computes the Jacobian, the linear parameters c,
+    % and the residual for the model with nonlinear parameters alpha.
+    % It is used by the functions Varpro and f_lsq.
+    %
+    % Notation: there are m data observations
+    %                     n1 basis functions (columns of Phi)
+    %                     n linear parameters c
+    %                       (n = n1, or n = n1 - 1)
+    %                     q nonlinear parameters alpha
+    %                     p nonzero columns of partial derivatives of Phi 
+    %
+    % Input:
+    %
+    %      alpha  q x 1   the nonlinear parameters,
+    %      Phi    m x n1  the basis functions Phi(alpha),
+    %      dPhi   m x p   the partial derivatives of Phi
+    %
+    % The variables W, y, q, m, n1, and n are also used.
+    %
+    % Output: 
+    %
+    %      Jacobian  m x p the Jacobian matrix, with J(i,k) = partial
+    %                      derivative of W resid(i) with respect to alpha(k).
+    %      c      n x 1 the optimal linear parameters for this choice of alpha.
+    %      wresid    m x 1 the weighted residual = W(y - Phi * c)
+    %      y_est     m x 1 the model estimates = Phi * c)
+    %      myrank    1 x 1 the rank of the matrix W*Phi.
+
+
+    % First we determine the optimal linear parameters c for
+    % the given values of alpha, and the resulting residual.
+    %
+    % We use the singular value decomposition to solve the linear least
+    % squares problem
+    %
+    %    min_{c} || W resid ||.
+    %       resid =  y - Phi * c.
+    %
+    % If W*Phi has any singular value less than m * its largest singular value, 
+    % these singular values are set to zero.
+
+    [U,S,V] = svd(W*Phi(:,1:n));
+
+    % Three cases: Usually n > 1, but n = 1 and n = 0 require
+    % special handling (one or no linear parameters).
+
+    if (n > 1)
+      s = diag(S);
+    elseif (n==1)
+      s = S;
+    else    %  n = 0
+      if isempty(Ind)
+        Jacobian = [];
+      else
+        Jacobian = zeros(length(y),length(alpha));
+        Jacobian(:,Ind(2,:)) = -W*dPhi;
+      end
+      c = [];
+      y_est = Phi;
+      wresid = W * (y - y_est);
+      myrank = 1;
+      return
+    end
+
+    tol = m * eps;
+    myrank = sum(s > tol*s(1) ); % number of singular values > tol*norm(W*Phi)
+    s = s(1:myrank);
+
+    if (myrank < n) & (~strcmp(options.Display,'off'))
+      disp(sprintf('Warning from VARPRO:'))
+      disp(sprintf('   The linear parameters are currently not well-determined.'))
+      disp(sprintf('   The rank of the matrix in the subproblem is %d',myrank))
+      disp(sprintf('   which is less than the n=%d linear parameters.',n))
+    end
+
+    yuse = y;
+    if (n < n1)
+      yuse  = y - Phi(:,n1); % extra function Phi(:,n+1)
+    end
+    temp  = U(:,1:myrank)' * (W*yuse);    
+    c = V(:,1:myrank) * (temp./s);
+    y_est = Phi(:,1:n) * c;
+    wresid = W * (yuse - y_est);
+    if (n < n1)
+      y_est = y_est + Phi(:,n1);
+    end
+
+    if (q == 0) | (isempty(dPhi))
+      Jacobian = [];
+      return
+    end
+
+    % Second, we compute the Jacobian.
+    % There are two pieces, which we call Jac1 and Jac2,
+    % with Jacobian = - (Jac1 + Jac2).
+    %
+    % The formula for Jac1 is (P D(W*Phi) pinv(W*Phi) y,
+    %             and Jac2 is ((W*Phi)^+})^T (P D(W*Phi))^T y.
+    % where  P           is the projection onto the orthogonal complement
+    %                       of the range of W*Phi,
+    %        D(W*Phi)    is the m x n x q tensor of derivatives of W*Phi,
+    %        pinv(W*Phi) is the pseudo-inverse of W*Phi.
+    %  (See Golub&Pereyra (1973) equation (5.4).  We use their notational  
+    %   conventions for multiplications by tensors.)
+    %
+    % Golub&Pereyra (2003), p. R5 break these formulas down by columns:
+    %     The j-th column of Jac1 is P D_j pinv(W*Phi) y
+    %                             =  P D_j c             
+    % and the j-th column of Jac2 is (P D_j pinv(W*Phi))^T y,
+    %                             =  (pinv(W*Phi))^T D_j^T P^T y
+    %                             =  (pinv(W*Phi))^T D_j^T wresid.
+    % where D_j is the m x n matrix of partial derivatives of W*Phi
+    %     with respect to alpha(j).
+
+    % We begin the computation by precomputing 
+    %       WdPhi, which contains the derivatives of W*Phi, and 
+    %       WdPhi_r, which contains WdPhi' * wresid.
+
+    WdPhi = W * dPhi;
+    WdPhi_r = WdPhi' * wresid;
+    T2 = zeros(n1, q);
+    ctemp = c;
+    if (n1 > n)
+      ctemp = [ctemp; 1];
+    end
+
+    %   Now we work column-by-column, for j=1:q.
+    %
+    %   We form Jac1 = D(W*Phi) ctemp.
+    %   After the loop, this matrix is multiplied by 
+    %        P = U(:,myrank+1:m)*(U(:,myrank+1:m)'
+    %   to complete the computation.
+    % 
+    %   We also form  T2 = (D_j(W*Phi))^T wresid  by unpacking
+    %   the information in WdPhi_r, using Ind.
+    %   After the loop, T2 is multiplied by the pseudoinverse
+    %       (pinv(W*Phi))^T = U(:,1:myrank) * diag(1./s) * (V(:,1:myrank)'
+    %   to complete the computation of Jac2.
+    %   Note: if n1 > n, last row of T2 is not needed.   
+
+    for j=1:q,                            % for each nonlinear parameter alpha(j)
+      range = find(Ind(2,:)==j);        % columns of WdPhi relevant to alpha(j)
+      indrows = Ind(1,range);           % relevant rows of ctemp
+      Jac1(:,j) = WdPhi(:,range) * ctemp(indrows);      
+      T2(indrows,j) = WdPhi_r(range);
+    end
+
+
+    Jac1 = U(:,myrank+1:m) * (U(:,myrank+1:m)' * Jac1);
+
+    T2 = diag(1 ./ s(1:myrank)) * (V(:,1:myrank)' * T2(1:n,:));
+    Jac2 = U(:,1:myrank) * T2;
+
+    Jacobian = -(Jac1 + Jac2);
+
+    if (mydebug)
+      disp(sprintf('VARPRO norm(neglected Jacobian)/norm(Jacobian) = %e',...
+        norm(Jac2,'fro')/norm(Jacobian,'fro') ))
+      if (myneglect)
+        disp('neglecting')
+        Jacobian = -Jac1;
+      end
+    end
+
+  end %-------------------------- End of formJacobian ----------------------
+
+end %------------------------------ End of varpro ------------------------
+

--- a/shared_test_code/src/models.rs
+++ b/shared_test_code/src/models.rs
@@ -12,6 +12,7 @@ use varpro::{model::errors::ModelError, prelude::*};
 /// using the trait directly without using the builder.
 /// This allows us to use caching of the intermediate results
 /// to calculate the derivatives more efficiently.
+#[derive(Debug, PartialEq)]
 pub struct DoubleExpModelWithConstantOffsetSepModel {
     /// the x vector associated with this model.
     /// We make this configurable to enable models to

--- a/shared_test_code/src/models.rs
+++ b/shared_test_code/src/models.rs
@@ -1,5 +1,4 @@
 use nalgebra::{DVector, Dyn, OMatrix, OVector, Vector2, Vector3, U2, U3};
-use varpro::model::builder::SeparableModelBuilderProxyWithDerivatives;
 use varpro::model::SeparableModel;
 use varpro::{model::errors::ModelError, prelude::*};
 

--- a/shared_test_code/src/models.rs
+++ b/shared_test_code/src/models.rs
@@ -276,6 +276,7 @@ impl LeastSquaresProblem<f64, Dyn, U5> for DoubleExponentialDecayFittingWithOffs
 /// # performance
 /// this model does reuse calculations but I think it could be optimized
 /// further
+#[derive(Clone, Debug, PartialEq)]
 pub struct OLearyExampleModel {
     /// the t vector
     t: DVector<f64>,

--- a/shared_test_code/src/models.rs
+++ b/shared_test_code/src/models.rs
@@ -285,6 +285,20 @@ pub struct OLearyExampleModel {
     phi: OMatrix<f64, Dyn, U2>,
 }
 
+impl OLearyExampleModel {
+    /// create a new model with the given t vector and initial guesses
+    pub fn new(t: DVector<f64>, initial_guesses: Vector3<f64>) -> Self {
+        let t_len = t.len();
+        let mut ret = Self {
+            t,
+            alpha: initial_guesses,
+            phi: OMatrix::<f64, Dyn, U2>::zeros_generic(Dyn(t_len), U2),
+        };
+        ret.set_params(initial_guesses).unwrap();
+        ret
+    }
+}
+
 impl SeparableNonlinearModel for OLearyExampleModel {
     type ScalarType = f64;
     type Error = ModelError;

--- a/shared_test_code/src/models.rs
+++ b/shared_test_code/src/models.rs
@@ -1,4 +1,4 @@
-use nalgebra::{DVector, Dyn, OMatrix, OVector, Vector2, Vector3, Vector4, U2, U3, U4};
+use nalgebra::{DVector, Dyn, OMatrix, OVector, Vector2, Vector3, U2, U3};
 use varpro::{model::errors::ModelError, prelude::*};
 
 #[derive(Clone)]

--- a/shared_test_code/src/models.rs
+++ b/shared_test_code/src/models.rs
@@ -1,4 +1,4 @@
-use nalgebra::{DVector, Dyn, OMatrix, OVector, Vector2, U2, U3};
+use nalgebra::{DVector, Dyn, OMatrix, OVector, Vector2, Vector3, Vector4, U2, U3, U4};
 use varpro::{model::errors::ModelError, prelude::*};
 
 #[derive(Clone)]
@@ -264,5 +264,127 @@ impl LeastSquaresProblem<f64, Dyn, U5> for DoubleExponentialDecayFittingWithOffs
         jacobian.set_column(4, &DVector::from_element(self.x.len(), 1.));
 
         Some(jacobian)
+    }
+}
+
+/// example function from the matlab code that was published as part of the
+/// O'Leary paper here: https://www.cs.umd.edu/~oleary/software/varpro/
+/// The model function is
+///
+///   f(t) = c1 exp(-alpha2 t)*cos(alpha3 t)
+///         + c2 exp(-alpha1 t)*cos(alpha2 t)
+/// # performance
+/// this model does reuse calculations but I think it could be optimized
+/// further
+pub struct OLearyExampleModel {
+    /// the t vector
+    t: DVector<f64>,
+    /// the current parameters (alpha1,alpha2,alpha3,alpha4)
+    alpha: Vector3<f64>,
+    /// the current evaluation of the model
+    phi: OMatrix<f64, Dyn, U2>,
+}
+
+impl SeparableNonlinearModel for OLearyExampleModel {
+    type ScalarType = f64;
+    type Error = ModelError;
+    type ParameterDim = U3;
+    type ModelDim = U2;
+    type OutputDim = Dyn;
+
+    fn parameter_count(&self) -> Self::ParameterDim {
+        U3 {}
+    }
+
+    fn base_function_count(&self) -> Self::ModelDim {
+        U2 {}
+    }
+
+    fn output_len(&self) -> Self::OutputDim {
+        Dyn(self.t.len())
+    }
+
+    fn set_params(
+        &mut self,
+        parameters: OVector<Self::ScalarType, Self::ParameterDim>,
+    ) -> Result<(), Self::Error> {
+        self.alpha = parameters;
+        let alpha1 = self.alpha[0];
+        let alpha2 = self.alpha[1];
+        let alpha3 = self.alpha[2];
+
+        let f1 = self.t.map(|t| f64::exp(-alpha2 * t) * f64::cos(alpha3 * t));
+        let f2 = self.t.map(|t| f64::exp(-alpha1 * t) * f64::cos(alpha2 * t));
+
+        self.phi = OMatrix::<f64, Dyn, U2>::from_columns(&[f1, f2]);
+        Ok(())
+    }
+
+    fn params(&self) -> OVector<Self::ScalarType, Self::ParameterDim> {
+        self.alpha
+    }
+
+    fn eval(
+        &self,
+    ) -> Result<OMatrix<Self::ScalarType, Self::OutputDim, Self::ModelDim>, Self::Error> {
+        Ok(self.phi.clone())
+    }
+
+    fn eval_partial_deriv(
+        &self,
+        derivative_index: usize,
+    ) -> Result<OMatrix<Self::ScalarType, Self::OutputDim, Self::ModelDim>, Self::Error> {
+        let mut derivs = OMatrix::<f64, Dyn, U2>::zeros_generic(Dyn(self.t.len()), U2);
+        let alpha1 = self.alpha[0];
+        let alpha2 = self.alpha[1];
+        let alpha3 = self.alpha[2];
+
+        // from the original matlab impl:
+        // % The nonzero partial derivatives of Phi with respect to alpha are
+        // %              d Phi_1 / d alpha_2 ,
+        // %              d Phi_1 / d alpha_3 ,
+        // %              d Phi_2 / d alpha_1 ,
+        // %              d Phi_2 / d alpha_2 ,
+        // % and this determines Ind.
+        // % The ordering of the columns of Ind is arbitrary but must match dPhi.
+
+        // % Evaluate the four nonzero partial derivatives of Phi at each of
+        // % the data points and store them in dPhi.
+
+        // dPhi 1 / dalpha 2 = -t .* Phi(:,1);
+        // dPhi 1 / dalpha 3 = -t .* exp(-alpha(2)*t).*sin(alpha(3)*t);
+        // dPhi 2 / dalpha 1 = -t .* Phi(:,2);
+        // dPhi 2 / dalpha 2 = -t .* exp(-alpha(1)*t).*sin(alpha(2)*t);
+
+        match derivative_index {
+            0 => {
+                // d/d alpha1
+                derivs.set_column(1, &self.phi.column(1).component_mul(&(-1. * &self.t)));
+            }
+            1 => {
+                // d/d alpha2
+                derivs.set_column(0, &self.phi.column(0).component_mul(&(-1. * &self.t)));
+                derivs.set_column(
+                    1,
+                    &self
+                        .t
+                        .map(|t| -t * (-alpha1 * t).exp() * (alpha2 * t).sin()),
+                );
+            }
+            2 => {
+                // d/d alpha3
+                derivs.set_column(
+                    0,
+                    &self
+                        .t
+                        .map(|t| -t * (-alpha2 * t).exp() * (alpha3 * t).sin()),
+                );
+            }
+            _ => {
+                unreachable!("derivative index must be 0,1,2");
+            }
+        }
+
+        Ok(derivs)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@
 //! # use varpro::model::*;
 //! # let problem : varpro::solvers::levmar::LevMarProblem<SeparableModel<f64>> = unimplemented!();
 //! use varpro::solvers::levmar::LevMarSolver;
-//! let (problem, report) = LevMarSolver::new().minimize(problem);
+//! let fit_result = LevMarSolver::new().fit(problem).unwrap();
 //! ```
 //! Finally, check the minimization report and, if successful, retrieve the nonlinear parameters `$\alpha$`
 //! using the [LevMarProblem::params](levenberg_marquardt::LeastSquaresProblem::params) and the linear
@@ -145,13 +145,9 @@
 //! # use varpro::prelude::*;
 //! # let problem : varpro::solvers::levmar::LevMarProblem<SeparableModel<f64>> = unimplemented!();
 //! # use varpro::solvers::levmar::LevMarSolver;
-//! # let (problem, report) = LevMarSolver::new().minimize(problem);
-//! assert!(
-//!     report.termination.was_successful(),
-//!     "Termination not successful"
-//! );
-//! let alpha = problem.params();
-//! let coeff = problem.linear_coefficients().unwrap();
+//! # let fit_result = LevMarSolver::new().fit(problem).unwrap();
+//! let alpha = fit_result.nonlinear_parameters();
+//! let coeff = fit_result.linear_coefficients().unwrap();
 //! ```
 //! If the minimization was successful, the nonlinear parameters `$\vec{\alpha}$`
 //! are now stored in the variable `alpha` and the linear coefficients `$\vec{c}$` are stored in `coeff`.
@@ -246,14 +242,15 @@
 //!     .build()
 //!     .unwrap();
 //! // 4. Solve using the fitting problem
-//! let (solved_problem, report) = LevMarSolver::new().minimize(problem);
-//! assert!(report.termination.was_successful());
+//! let fit_result = LevMarSolver::new()
+//!     .fit(problem)
+//!     .expect("fit must succeed");
 //! // the nonlinear parameters after fitting
 //! // they are in the same order as the parameter names given to the model
-//! let alpha = solved_problem.params();
+//! let alpha = fit_result.nonlinear_parameters();
 //! // the linear coefficients after fitting
 //! // they are in the same order as the basis functions that were added to the model
-//! let c = solved_problem.linear_coefficients().unwrap();
+//! let c = fit_result.linear_coefficients().unwrap();
 //! ```
 //!
 //! # References and Further Reading

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,11 +257,11 @@
 //! let c = fit_result.linear_coefficients().unwrap();
 //! ```
 //!
-//! # Example 2: A Mixed exponential and trigonometric model
+//! # Example 2: Mixed exponential and trigonometric model
 //!
 //! This example is taken from the matlab code that is published as part of the
 //! O'Leary 2013 paper and fits a mixed exponential and trigonometric model to
-//! some noisy data.
+//! some noisy and weighted data.
 //!
 //! In keeping with the element-wise notation above, we can write the model
 //! as

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,8 @@ pub mod model;
 pub mod prelude;
 /// solvers for the nonlinear minimization problem
 pub mod solvers;
+/// statistics of the fit
+pub mod statistics;
 
 /// private module that contains helper functionality for linear algebra that is not yet
 /// implemented in the nalgebra crate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,9 +274,9 @@ pub mod solvers;
 /// statistics of the fit
 pub mod statistics;
 
-/// private module that contains helper functionality for linear algebra that is not yet
+/// helper module containing some commonly useful types
 /// implemented in the nalgebra crate
-mod linalg_helpers;
+pub mod util;
 
 #[cfg(any(test, doctest))]
 pub mod test_helpers;

--- a/src/model/builder/mod.rs
+++ b/src/model/builder/mod.rs
@@ -71,7 +71,7 @@ pub mod error;
 /// ```
 /// using single precision (`f32`) floats.
 ///
-/// ** Linear Independence**
+/// **Linear Independence**
 ///
 /// The basis functions must be linearly independent. That means adding `$\vec{f_1}(\vec{x})=\vec{x}$`
 /// and `$\vec{f_1}(\vec{x})=2\,\vec{x}$` is forbidden. Adding functions that

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -33,7 +33,7 @@ pub mod test;
 /// \vec{f}(\vec{x},\vec{\alpha},\vec{c}) = \sum_{j=1}^M c_j \cdot \vec{f}_j(S_j(\vec{\alpha})),
 /// ```
 ///
-/// where `$\vec{c}=(c_1,\dots,\c_M)$` are the coefficients of the model base functions `$f_j$` and
+/// where `$\vec{c}=(c_1,\dots,c_M)$` are the coefficients of the model base functions `$f_j$` and
 /// `$S_j(\vec{\alpha})$` is a subset of the nonlinear model parameters that may be different
 /// for each model function. The base functions should depend on the model parameters nonlinearly.
 /// Linear parameters should be in the coefficient vector `$\vec{c}$` only.

--- a/src/solvers/levmar/.mod.rs.rustfmt
+++ b/src/solvers/levmar/.mod.rs.rustfmt
@@ -156,39 +156,26 @@ where
 // fitting problem, which is the jacobian `$\vec{f}(\vec{\alpha},\vec{c}(\vec{\alpha}))$`,
 // where `$\vec{c}(\vec{\alpha})$` is the linear coefficients that solve the linear problem.
 // see also the O'Leary matlab code.
-fn model_function_jacobian<Model>(
-    model: Model,
-) -> OMatrix<
-    Model::ScalarType,
-    Model::OutputDim,
-    <Model::ModelDim as DimAdd<Model::ParameterDim>>::Output,
->
+fn model_function_jacobian<Model>(model: Model) -> OMatrix<Model::ScalarType, Model::OutputDim, <Model::ModelDim as DimAdd<Model::ParameterDim>>::Output>
 where
     Model: SeparableNonlinearModel,
-    Model::ScalarType: Float + Zero + Scalar + ComplexField,
-    nalgebra::DefaultAllocator:
-        nalgebra::allocator::Allocator<Model::ScalarType, Model::ParameterDim>,
-    nalgebra::DefaultAllocator:
-        nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim, Model::ModelDim>,
-    nalgebra::DefaultAllocator:
-        nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim, Model::ParameterDim>,
+    nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<
+        Model::ScalarType,
+        Model::ParameterDim,
+    >,
     nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<
         Model::ScalarType,
         Model::OutputDim,
-        <Model::ModelDim as DimAdd<Model::ParameterDim>>::Output,
+        Model::ModelDim,
     >,
-    <Model as model::SeparableNonlinearModel>::ModelDim:
-        nalgebra::DimAdd<<Model as model::SeparableNonlinearModel>::ParameterDim>,
+    nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<
+        Model::ScalarType,
+        Model::OutputDim,
+    <Model::ModelDim as DimAdd<Model::ParameterDim>>::Output
+    >,
+    <Model as model::SeparableNonlinearModel>::ModelDim: nalgebra::DimAdd<<Model as model::SeparableNonlinearModel>::ParameterDim>,
 {
-    // the part of the jacobian that contains the derivatives
-    // with respect to the nonlinear parameters
-    let jacobian_matrix_for_nonlinear_params =
-        OMatrix::<Model::ScalarType, Model::OutputDim, Model::ParameterDim>::zeros_generic(
-            model.output_len(),
-            model.parameter_count(),
-        );
-
-    todo!();
+    todo!()
 }
 
 // helper function to concatenate two nalgebra matrices

--- a/src/solvers/levmar/builder.rs
+++ b/src/solvers/levmar/builder.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::solvers::levmar::LevMarProblem;
-use crate::util::weights::Weights;
+use crate::util::Weights;
 use levenberg_marquardt::LeastSquaresProblem;
 use nalgebra::{ComplexField, Const, DefaultAllocator, Dim, DimMin, DimSub, OVector, Scalar};
 use num_traits::{Float, Zero};

--- a/src/solvers/levmar/builder.rs
+++ b/src/solvers/levmar/builder.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
-use crate::solvers::levmar::weights::Weights;
 use crate::solvers::levmar::LevMarProblem;
+use crate::util::weights::Weights;
 use levenberg_marquardt::LeastSquaresProblem;
 use nalgebra::{ComplexField, Const, DefaultAllocator, Dim, DimMin, DimSub, OVector, Scalar};
 use num_traits::{Float, Zero};

--- a/src/solvers/levmar/builder.rs
+++ b/src/solvers/levmar/builder.rs
@@ -62,6 +62,7 @@ pub enum LevMarBuilderError {
 /// the [build](LevMarProblemBuilder::build) method can be called. This returns a [Result](std::result::Result)
 /// type that contains the finished model iff all mandatory fields have been set with valid values. Otherwise
 /// it contains an error variant.
+#[derive(Clone)]
 pub struct LevMarProblemBuilder<Model>
 where
     Model::ScalarType: Scalar + ComplexField + Copy,
@@ -87,27 +88,6 @@ where
     /// all weights were 1.
     /// Must have the same length as x and y.
     weights: Weights<Model::ScalarType, Model::OutputDim>,
-}
-
-impl<Model> Clone for LevMarProblemBuilder<Model>
-where
-    Model::ScalarType: Scalar + ComplexField + Copy,
-    <Model::ScalarType as ComplexField>::RealField:
-        Float + Mul<Model::ScalarType, Output = Model::ScalarType>,
-    Model: SeparableNonlinearModel + Clone,
-    DefaultAllocator:
-        nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim, Model::ModelDim>,
-    DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim>,
-    DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::ParameterDim>,
-{
-    fn clone(&self) -> Self {
-        Self {
-            y: self.y.clone(),
-            separable_model: self.separable_model.clone(),
-            epsilon: self.epsilon,
-            weights: self.weights.clone(),
-        }
-    }
 }
 
 impl<Model> LevMarProblemBuilder<Model>

--- a/src/solvers/levmar/builder/test.rs
+++ b/src/solvers/levmar/builder/test.rs
@@ -1,8 +1,8 @@
-use crate::linalg_helpers::DiagMatrix;
 use crate::model::test::MockSeparableNonlinearModel;
 use crate::solvers::levmar::builder::LevMarBuilderError;
-use crate::solvers::levmar::weights::Weights;
 use crate::solvers::levmar::LevMarProblemBuilder;
+use crate::util::weights::Weights;
+use crate::util::DiagMatrix;
 use assert_matches::assert_matches;
 use nalgebra::{DMatrix, DVector};
 

--- a/src/solvers/levmar/builder/test.rs
+++ b/src/solvers/levmar/builder/test.rs
@@ -1,8 +1,8 @@
 use crate::model::test::MockSeparableNonlinearModel;
 use crate::solvers::levmar::builder::LevMarBuilderError;
 use crate::solvers::levmar::LevMarProblemBuilder;
-use crate::util::weights::Weights;
 use crate::util::DiagMatrix;
+use crate::util::Weights;
 use assert_matches::assert_matches;
 use nalgebra::{DMatrix, DVector};
 

--- a/src/solvers/levmar/builder/test.rs
+++ b/src/solvers/levmar/builder/test.rs
@@ -124,7 +124,7 @@ fn builder_gives_errors_for_wrong_data_length() {
     let y = DVector::from(vec![
         4.0000, 2.9919, 2.3423, 1.9186, 1.6386, 1.4507, 1.3227, 1.2342, 1.1720, 1.1276, 1.0956,
     ]);
-    let _initial_guess = vec![1., 2.];
+    let _initial_guess = [1., 2.];
 
     let wrong_output_len = y.len() - 1;
     model
@@ -145,7 +145,7 @@ fn builder_gives_errors_for_zero_length_data() {
     let y = DVector::from(vec![
         4.0000, 2.9919, 2.3423, 1.9186, 1.6386, 1.4507, 1.3227, 1.2342, 1.1720, 1.1276, 1.0956,
     ]);
-    let _initial_guess = vec![1., 2.];
+    let _initial_guess = [1., 2.];
 
     let output_len = y.len();
     model.expect_output_len().returning(move || output_len);
@@ -166,7 +166,7 @@ fn builder_gives_errors_for_wrong_length_of_weights() {
     let y = DVector::from(vec![
         4.0000, 2.9919, 2.3423, 1.9186, 1.6386, 1.4507, 1.3227, 1.2342, 1.1720, 1.1276, 1.0956,
     ]);
-    let _initial_guess = vec![1., 2.];
+    let _initial_guess = [1., 2.];
 
     let output_len = y.len();
     model.expect_output_len().returning(move || output_len);

--- a/src/solvers/levmar/mod.rs
+++ b/src/solvers/levmar/mod.rs
@@ -278,9 +278,12 @@ where
         DefaultAllocator: nalgebra::allocator::Allocator<<Model as model::SeparableNonlinearModel>::ScalarType, Model::OutputDim, <<Model as model::SeparableNonlinearModel>::ModelDim as DimAdd<<Model as model::SeparableNonlinearModel>::ParameterDim>>::Output>,
         DefaultAllocator: nalgebra::allocator::Allocator<<Model as model::SeparableNonlinearModel>::ScalarType,  <<Model as model::SeparableNonlinearModel>::ModelDim as DimAdd<<Model as model::SeparableNonlinearModel>::ParameterDim>>::Output,Model::OutputDim>,
     {
-        let (problem, report) = self.solver.minimize(problem);
-        if !report.termination.was_successful() {
-            return Err(FitResult::new(problem, report));
+        let FitResult {
+            problem,
+            minimization_report,
+        } = self.fit(problem)?;
+        if !minimization_report.termination.was_successful() {
+            return Err(FitResult::new(problem, minimization_report));
         }
 
         if let Ok(statistics) = FitStatistics::try_calculate(
@@ -289,9 +292,9 @@ where
             problem.weights(),
             problem.linear_coefficients().unwrap(),
         ) {
-            Ok((FitResult::new(problem, report), statistics))
+            Ok((FitResult::new(problem, minimization_report), statistics))
         } else {
-            Err(FitResult::new(problem, report))
+            Err(FitResult::new(problem, minimization_report))
         }
     }
 }

--- a/src/solvers/levmar/mod.rs
+++ b/src/solvers/levmar/mod.rs
@@ -285,7 +285,7 @@ where
 
         if let Ok(statistics) = FitStatistics::try_calculate(
             problem.model(),
-            problem.data(),
+            problem.weighted_data(),
             problem.weights(),
             problem.linear_coefficients().unwrap(),
         ) {
@@ -480,8 +480,10 @@ where
         &self.weights
     }
 
-    /// the data that we are trying to fit
-    pub fn data(&self) -> &OVector<Model::ScalarType, Model::OutputDim> {
+    /// the weighted data vector `$\vec{y}_w$` to which to fit the model. Note
+    /// that the weights are already applied to the data vector and this
+    /// is not the original data vector
+    pub fn weighted_data(&self) -> &OVector<Model::ScalarType, Model::OutputDim> {
         &self.y_w
     }
 }

--- a/src/solvers/levmar/mod.rs
+++ b/src/solvers/levmar/mod.rs
@@ -221,6 +221,7 @@ where
 
     /// Try to solve the given varpro minimization problem. The parameters of
     /// the problem which are set when this function is called are used as the initial guess
+    ///
     /// # Returns
     /// On success, returns an Ok value containing the fit result, which contains
     /// the final state of the problem as well as some convenience functions that
@@ -256,6 +257,12 @@ where
         }
     }
 
+    /// Same as the [LevMarProblem::fit] function but also calculates some additional
+    /// statistical information about the fit, if the fit was successful.
+    ///
+    /// # Returns
+    /// See also the [LevMarProblem::fit] function, but also returns statistical
+    /// information about the fit that can be queried, if the fit was successful.
     pub fn fit_with_statistics(&self,problem : LevMarProblem<Model>) -> Result<(FitResult<Model>,FitStatistics<Model>),FitResult<Model>>
     where Model:SeparableNonlinearModel,
         LevMarProblem<Model>:LeastSquaresProblem<Model::ScalarType,Model::OutputDim, Model::ParameterDim>,

--- a/src/solvers/levmar/mod.rs
+++ b/src/solvers/levmar/mod.rs
@@ -284,6 +284,7 @@ where
             * model_function_jacobian(problem.model(), problem.linear_coefficients().unwrap())
                 .unwrap();
         println!("H: {}", hmat);
+
         let weighted_residuals = problem.residuals().unwrap();
         let output_len = problem.model.output_len().value();
         let degrees_of_freedom = problem.model().parameter_count().value()
@@ -295,7 +296,10 @@ where
             / Float::sqrt(Model::ScalarType::from_usize(output_len - degrees_of_freedom).unwrap());
         let hth_inv = (hmat.transpose() * hmat).try_inverse().unwrap();
         let covariance_matrix = hth_inv * sigma * sigma;
-        let statistics = FitStatistics { covariance_matrix };
+        let statistics = FitStatistics {
+            covariance_matrix,
+            weighted_residuals: todo!(),
+        };
         (problem, statistics)
     }
 }

--- a/src/solvers/levmar/mod.rs
+++ b/src/solvers/levmar/mod.rs
@@ -223,6 +223,7 @@ where
     /// the problem which are set when this function is called are used as the initial guess
     ///
     /// # Returns
+    ///
     /// On success, returns an Ok value containing the fit result, which contains
     /// the final state of the problem as well as some convenience functions that
     /// allow to query the optimal parameters. Note that success of failure is
@@ -261,8 +262,9 @@ where
     /// statistical information about the fit, if the fit was successful.
     ///
     /// # Returns
-    /// See also the [LevMarProblem::fit] function, but also returns statistical
-    /// information about the fit that can be queried, if the fit was successful.
+    ///
+    /// See also the [LevMarProblem::fit] function, but on success also returns statistical
+    /// information about the fit.
     pub fn fit_with_statistics(&self,problem : LevMarProblem<Model>) -> Result<(FitResult<Model>,FitStatistics<Model>),FitResult<Model>>
     where Model:SeparableNonlinearModel,
         LevMarProblem<Model>:LeastSquaresProblem<Model::ScalarType,Model::OutputDim, Model::ParameterDim>,
@@ -293,11 +295,15 @@ where
             return Err(FitResult::new(problem, minimization_report));
         }
 
+        let Some(coefficients) = problem.linear_coefficients() else {
+            return Err(FitResult::new(problem, minimization_report));
+        };
+
         if let Ok(statistics) = FitStatistics::try_calculate(
             problem.model(),
             problem.weighted_data(),
             problem.weights(),
-            problem.linear_coefficients().unwrap(),
+            coefficients,
         ) {
             Ok((FitResult::new(problem, minimization_report), statistics))
         } else {

--- a/src/solvers/levmar/mod.rs
+++ b/src/solvers/levmar/mod.rs
@@ -149,8 +149,8 @@ where
         }
     }
 
-    /// convenience function to get the nonlinear parameters of the model
-    /// fitting process has finished.
+    /// convenience function to get the nonlinear parameters of the model after
+    /// the fitting process has finished.
     pub fn nonlinear_parameters(&self) -> OVector<Model::ScalarType, Model::ParameterDim> {
         self.problem.model().params()
     }
@@ -162,7 +162,8 @@ where
     }
 
     /// whether the fit was deemeed successful. The fit might still be not
-    /// be optimal.
+    /// be optimal for numerical reasons, but the minimization process
+    /// terminated successfully.
     pub fn was_successful(&self) -> bool {
         self.minimization_report.termination.was_successful()
     }
@@ -225,7 +226,7 @@ where
     /// correspond to a failed minimization in some cases.
     /// On failure (when the minimization was not deemeed successful), returns
     /// an error with the same information as in the success case.
-    pub fn fit(&self,problem : LevMarProblem<Model>) -> (LevMarProblem<Model>,MinimizationReport<Model::ScalarType>)
+    pub fn fit(&self,problem : LevMarProblem<Model>) -> Result<FitResult<Model>,FitResult<Model>>
     where Model:SeparableNonlinearModel,
         LevMarProblem<Model>:LeastSquaresProblem<Model::ScalarType,Model::OutputDim, Model::ParameterDim>,
         DefaultAllocator: Allocator<Model::ScalarType, Model::ParameterDim> + Reallocator<Model::ScalarType, Model::OutputDim, Model::ParameterDim,DimMaximum<Model::OutputDim,Model::ParameterDim>,Model::ParameterDim> + Allocator<usize,Model::ParameterDim>,
@@ -245,11 +246,13 @@ where
     {
         let (problem, report) = self.solver.minimize(problem);
         let result = FitResult::new(problem, report);
-        todo!()
+        if result.was_successful() {
+            Ok(result)
+        } else {
+            Err(result)
+        }
     }
 
-    /// performs the minimization and also generates statistics about the minimization
-    /// iff the computation was successful
     pub fn fit_with_statistics(&self,problem : LevMarProblem<Model>) -> (LevMarProblem<Model>,FitStatistics<Model::ScalarType,Model::ModelDim, Model::ParameterDim>)
     where Model:SeparableNonlinearModel,
         LevMarProblem<Model>:LeastSquaresProblem<Model::ScalarType,Model::OutputDim, Model::ParameterDim>,

--- a/src/solvers/levmar/mod.rs
+++ b/src/solvers/levmar/mod.rs
@@ -36,6 +36,7 @@ where
 
 /// A helper type that contains the fitting problem after the
 /// minimization, as well as a report and some convenience functions
+#[derive(Debug)]
 pub struct FitResult<Model>
 where
     Model: SeparableNonlinearModel,

--- a/src/solvers/levmar/mod.rs
+++ b/src/solvers/levmar/mod.rs
@@ -13,9 +13,8 @@ use thiserror::Error as ThisError;
 mod builder;
 #[cfg(any(test, doctest))]
 mod test;
-mod weights;
 
-use crate::solvers::levmar::weights::Weights;
+use crate::util::weights::Weights;
 pub use builder::LevMarProblemBuilder;
 /// type alias for the solver of the [levenberg_marquardt](https://crates.io/crates/levenberg-marquardt) crate
 // pub use levenberg_marquardt::LevenbergMarquardt as LevMarSolver;
@@ -292,8 +291,8 @@ where
         let sigma: Model::ScalarType = weighted_residuals.norm()
             / Float::sqrt(Model::ScalarType::from_usize(output_len - degrees_of_freedom).unwrap());
         let hth_inv = (hmat.transpose() * hmat).try_inverse().unwrap();
-        let covariance = hth_inv * sigma * sigma;
-        let statistics = FitStatistics { covariance };
+        let covariance_matrix = hth_inv * sigma * sigma;
+        let statistics = FitStatistics { covariance_matrix };
         (problem, statistics)
     }
 }

--- a/src/solvers/levmar/mod.rs
+++ b/src/solvers/levmar/mod.rs
@@ -253,7 +253,7 @@ where
         }
     }
 
-    pub fn fit_with_statistics(&self,problem : LevMarProblem<Model>) -> (LevMarProblem<Model>,FitStatistics<Model::ScalarType,Model::ModelDim, Model::ParameterDim>)
+    pub fn fit_with_statistics(&self,problem : LevMarProblem<Model>) -> (LevMarProblem<Model>,FitStatistics<Model>)
     where Model:SeparableNonlinearModel,
         LevMarProblem<Model>:LeastSquaresProblem<Model::ScalarType,Model::OutputDim, Model::ParameterDim>,
         DefaultAllocator: Allocator<Model::ScalarType, Model::ParameterDim> + Reallocator<Model::ScalarType, Model::OutputDim, Model::ParameterDim,DimMaximum<Model::OutputDim,Model::ParameterDim>,Model::ParameterDim> + Allocator<usize,Model::ParameterDim>,

--- a/src/solvers/levmar/mod.rs
+++ b/src/solvers/levmar/mod.rs
@@ -14,7 +14,7 @@ mod builder;
 #[cfg(any(test, doctest))]
 mod test;
 
-use crate::util::weights::Weights;
+use crate::util::Weights;
 pub use builder::LevMarProblemBuilder;
 /// type alias for the solver of the [levenberg_marquardt](https://crates.io/crates/levenberg-marquardt) crate
 // pub use levenberg_marquardt::LevenbergMarquardt as LevMarSolver;
@@ -310,12 +310,7 @@ where
     }
 }
 
-// a helper function that calculates the jacobian of the
-// model function `$\vec{f}(\vec{\alpha},\vec{c})$` evaluated at the parameters `$(\vec{c},\vec{\alpha})$`
-// This is not the same as the jacobian of the
-// fitting problem, which is the jacobian `$\vec{f}(\vec{\alpha},\vec{c}(\vec{\alpha}))$`,
-// where `$\vec{c}(\vec{\alpha})$` is the linear coefficients that solve the linear problem.
-// see also the O'Leary matlab code.
+//@todo remove
 fn model_function_jacobian<Model>(
     model: &Model,
     c: OVector<Model::ScalarType, Model::ModelDim>,
@@ -372,7 +367,7 @@ where
     ))
 }
 
-// helper function to concatenate two nalgebra matrices
+//@ todo remove
 fn concat_colwise<T, R, C1, C2, S1, S2>(
     left: Matrix<T, R, C1, S1>,
     right: Matrix<T, R, C2, S2>,

--- a/src/solvers/levmar/mod.rs
+++ b/src/solvers/levmar/mod.rs
@@ -4,7 +4,7 @@ use nalgebra::allocator::{Allocator, Reallocator};
 use nalgebra::storage::Owned;
 use nalgebra::{
     ComplexField, Const, DefaultAllocator, Dim, DimMax, DimMaximum, DimMin, DimSub, Matrix,
-    OVector, RawStorageMut, RealField, Scalar, Storage, UninitMatrix, Vector, SVD,
+    OVector, RawStorageMut, RealField, Scalar, Storage, UninitMatrix, Vector, SVD, DMatrix, OMatrix, U3, U4,
 };
 
 mod builder;
@@ -17,7 +17,7 @@ pub use builder::LevMarProblemBuilder;
 /// type alias for the solver of the [levenberg_marquardt](https://crates.io/crates/levenberg-marquardt) crate
 // pub use levenberg_marquardt::LevenbergMarquardt as LevMarSolver;
 use levenberg_marquardt::LevenbergMarquardt;
-use num_traits::Float;
+use num_traits::{Float, Zero};
 use std::ops::Mul;
 
 /// A thin wrapper around the
@@ -84,21 +84,10 @@ where
         Model::ScalarType: Scalar + ComplexField + Copy + RealField + Float,
         <<Model as SeparableNonlinearModel>::ScalarType as ComplexField>::RealField: Mul<Model::ScalarType, Output = Model::ScalarType> + Float,
         Model: SeparableNonlinearModel,
-        DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::ParameterDim>,
-        DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::ParameterDim,Model::OutputDim>,
-        DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim, Model::ModelDim>,
         DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::ModelDim>,
         DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim>,
         <DefaultAllocator as nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim>>::Buffer: Storage<Model::ScalarType, Model::OutputDim>,
             <DefaultAllocator as nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim>>::Buffer: RawStorageMut<Model::ScalarType, Model::OutputDim>,
-        DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim, Model::ParameterDim>,
-        DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, <Model::OutputDim as DimMin<Model::ModelDim>>::Output>,
-        DefaultAllocator: nalgebra::allocator::Allocator<(usize, usize), <Model::OutputDim as DimMin<Model::ModelDim>>::Output>,
-        DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, <Model::OutputDim as DimMin<Model::ModelDim>>::Output, Model::OutputDim>,
-        DefaultAllocator: nalgebra::allocator::Allocator<<Model::ScalarType as ComplexField> ::RealField, <<Model::OutputDim as DimMin<Model::ModelDim>>::Output as DimSub<Const<1>>>::Output>,
-        DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, <<Model::OutputDim as DimMin<Model::ModelDim>>::Output as DimSub<Const<1>>>::Output>,
-        DefaultAllocator: nalgebra::allocator::Allocator<(<Model::ScalarType as ComplexField>::RealField, usize), <Model::OutputDim as DimMin<Model::ModelDim>>::Output>,
-        <Model::OutputDim as DimMin<Model::ModelDim>>::Output: DimSub<nalgebra::dimension::Const<1>> ,
         Model::OutputDim: DimMin<Model::ModelDim>,
         DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, <Model::OutputDim as DimMin<Model::ModelDim>>::Output, Model::ModelDim>,
         DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim, <Model::OutputDim as DimMin<Model::ModelDim>>::Output>,
@@ -118,21 +107,10 @@ where
         Model::ScalarType: Scalar + ComplexField + Copy + RealField + Float,
         <<Model as SeparableNonlinearModel>::ScalarType as ComplexField>::RealField: Mul<Model::ScalarType, Output = Model::ScalarType> + Float,
         Model: SeparableNonlinearModel,
-        DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::ParameterDim>,
-        DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::ParameterDim,Model::OutputDim>,
-        DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim, Model::ModelDim>,
         DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::ModelDim>,
         DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim>,
         <DefaultAllocator as nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim>>::Buffer: Storage<Model::ScalarType, Model::OutputDim>,
             <DefaultAllocator as nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim>>::Buffer: RawStorageMut<Model::ScalarType, Model::OutputDim>,
-        DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim, Model::ParameterDim>,
-        DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, <Model::OutputDim as DimMin<Model::ModelDim>>::Output>,
-        DefaultAllocator: nalgebra::allocator::Allocator<(usize, usize), <Model::OutputDim as DimMin<Model::ModelDim>>::Output>,
-        DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, <Model::OutputDim as DimMin<Model::ModelDim>>::Output, Model::OutputDim>,
-        DefaultAllocator: nalgebra::allocator::Allocator<<Model::ScalarType as ComplexField> ::RealField, <<Model::OutputDim as DimMin<Model::ModelDim>>::Output as DimSub<Const<1>>>::Output>,
-        DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, <<Model::OutputDim as DimMin<Model::ModelDim>>::Output as DimSub<Const<1>>>::Output>,
-        DefaultAllocator: nalgebra::allocator::Allocator<(<Model::ScalarType as ComplexField>::RealField, usize), <Model::OutputDim as DimMin<Model::ModelDim>>::Output>,
-        <Model::OutputDim as DimMin<Model::ModelDim>>::Output: DimSub<nalgebra::dimension::Const<1>> ,
         Model::OutputDim: DimMin<Model::ModelDim>,
         DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, <Model::OutputDim as DimMin<Model::ModelDim>>::Output, Model::ModelDim>,
         DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim, <Model::OutputDim as DimMin<Model::ModelDim>>::Output>,
@@ -140,11 +118,19 @@ where
         <Model as model::SeparableNonlinearModel>::OutputDim: DimMax<<Model as model::SeparableNonlinearModel>::ParameterDim>,
         <Model as model::SeparableNonlinearModel>::OutputDim: DimMin<<Model as model::SeparableNonlinearModel>::ParameterDim>
     {
-        let (model, report) = self.solver.minimize(problem);
-
+        let (problem, report) = self.solver.minimize(problem);
+        
         todo!()
     }
 
+}
+
+// helper function to concatenate two nalgebra matrices
+fn concat_matrices<T:Scalar+Zero>(first : DMatrix<T>,second: DMatrix<T>) -> DMatrix<T> {
+    let mut result = DMatrix::zeros(first.nrows()+second.nrows(),first.ncols());
+    result.slice_mut((0,0),(first.nrows(),first.ncols())).copy_from(&first);
+    result.slice_mut((first.nrows(),0),(second.nrows(),second.ncols())).copy_from(&second);
+    result
 }
 
 /// helper structure that stores the cached calculations,
@@ -308,6 +294,11 @@ where
         self.cached
             .as_ref()
             .map(|cache| cache.linear_coefficients.clone())
+    }
+
+    /// access the contained model immutably
+    pub fn model(&self) -> &Model {
+        &self.model
     }
 }
 

--- a/src/solvers/levmar/mod.rs
+++ b/src/solvers/levmar/mod.rs
@@ -157,7 +157,7 @@ where
 
     /// convenience function to get the linear coefficients after the fit has
     /// finished
-    pub fn linear_coefficients(&self) -> Option<OVector<Model::ScalarType, Model::ModelDim>> {
+    pub fn linear_coefficients(&self) -> Option<&OVector<Model::ScalarType, Model::ModelDim>> {
         self.problem.linear_coefficients()
     }
 
@@ -559,10 +559,8 @@ where
     /// Either the current best estimate coefficients or None, if none were calculated or the solver
     /// encountered an error. After the solver finished, this is the least squares best estimate
     /// for the linear coefficients of the base functions.
-    pub fn linear_coefficients(&self) -> Option<OVector<Model::ScalarType, Model::ModelDim>> {
-        self.cached
-            .as_ref()
-            .map(|cache| cache.linear_coefficients.clone())
+    pub fn linear_coefficients(&self) -> Option<&OVector<Model::ScalarType, Model::ModelDim>> {
+        self.cached.as_ref().map(|cache| &cache.linear_coefficients)
     }
 
     /// access the contained model immutably

--- a/src/solvers/levmar/mod.rs
+++ b/src/solvers/levmar/mod.rs
@@ -212,11 +212,7 @@ where
         <Model as model::SeparableNonlinearModel>::OutputDim: DimMax<<Model as model::SeparableNonlinearModel>::ParameterDim>,
         <Model as model::SeparableNonlinearModel>::OutputDim: DimMin<<Model as model::SeparableNonlinearModel>::ParameterDim>
     {
-        let result = match self.fit(problem) {
-            Ok(result) => result,
-            Err(result) => result,
-        };
-        (result.problem, result.minimization_report)
+        self.solver.minimize(problem)
     }
 
     /// Try to solve the given varpro minimization problem. The parameters of
@@ -249,7 +245,8 @@ where
         <Model as model::SeparableNonlinearModel>::OutputDim: DimMax<<Model as model::SeparableNonlinearModel>::ParameterDim>,
         <Model as model::SeparableNonlinearModel>::OutputDim: DimMin<<Model as model::SeparableNonlinearModel>::ParameterDim>
     {
-        let (problem, report) = self.solver.minimize(problem);
+        #[allow(deprecated)]
+        let (problem, report) = self.minimize(problem);
         let result = FitResult::new(problem, report);
         if result.was_successful() {
             Ok(result)

--- a/src/solvers/levmar/test.rs
+++ b/src/solvers/levmar/test.rs
@@ -4,7 +4,7 @@ use crate::test_helpers::differentiation::numerical_derivative;
 use crate::test_helpers::get_double_exponential_model_with_constant_offset;
 use approx::assert_relative_eq;
 use levenberg_marquardt::differentiate_numerically;
-use nalgebra::{DVector};
+use nalgebra::DVector;
 
 // test that the jacobian of the least squares problem is correct if the parameter guesses
 // are correct. I observed that the numerical differentiation inside the levmar crate and my implementation

--- a/src/solvers/levmar/test.rs
+++ b/src/solvers/levmar/test.rs
@@ -227,36 +227,3 @@ fn levmar_problem_set_params_sets_the_model_parameters_when_built() {
         .build()
         .expect("Building a valid solver must not return an error.");
 }
-
-#[test]
-fn matrix_concatenation_for_dynamic_matrices() {
-    // two DMatrix instances with the same number of rows but
-    // different number of columns
-    let lhs = DMatrix::from_column_slice(2, 3, &[1., 2., 3., 4., 5., 6.]);
-    let rhs = DMatrix::from_column_slice(2, 2, &[7., 8., 9., 10.]);
-    let concat = DMatrix::from_column_slice(2, 5, &[1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]);
-    assert_relative_eq!(concat, concat_colwise(lhs, rhs));
-}
-
-#[test]
-// the same test as above but lhs is a fixed column size matrix
-fn matrix_concatenation_for_fixed_and_dyn_size_matrices() {
-    // two DMatrix instances with the same number of rows but
-    // different number of columns
-    let lhs = OMatrix::<f64, Dyn, U3>::from_column_slice(&[1., 2., 3., 4., 5., 6.]);
-    let rhs = DMatrix::from_column_slice(2, 2, &[7., 8., 9., 10.]);
-    let concat = DMatrix::from_column_slice(2, 5, &[1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]);
-    assert_relative_eq!(concat, concat_colwise(lhs, rhs));
-}
-
-#[test]
-// same test as above, but both matrices are fixed column size
-fn matrix_concatenation_for_fixed_size_matrices() {
-    // two DMatrix instances with the same number of rows but
-    // different number of columns
-    let lhs = OMatrix::<f64, U2, U3>::from_column_slice(&[1., 2., 3., 4., 5., 6.]);
-    let rhs = OMatrix::<f64, U2, U2>::from_column_slice(&[7., 8., 9., 10.]);
-    let concat =
-        OMatrix::<f64, U2, U5>::from_column_slice(&[1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]);
-    assert_relative_eq!(concat, concat_colwise(lhs, rhs));
-}

--- a/src/solvers/levmar/test.rs
+++ b/src/solvers/levmar/test.rs
@@ -4,7 +4,7 @@ use crate::test_helpers::differentiation::numerical_derivative;
 use crate::test_helpers::get_double_exponential_model_with_constant_offset;
 use approx::assert_relative_eq;
 use levenberg_marquardt::differentiate_numerically;
-use nalgebra::DVector;
+use nalgebra::{DVector, U2, U5};
 
 // test that the jacobian of the least squares problem is correct if the parameter guesses
 // are correct. I observed that the numerical differentiation inside the levmar crate and my implementation
@@ -226,4 +226,37 @@ fn levmar_problem_set_params_sets_the_model_parameters_when_built() {
         .observations(y)
         .build()
         .expect("Building a valid solver must not return an error.");
+}
+
+#[test]
+fn matrix_concatenation_for_dynamic_matrices() {
+    // two DMatrix instances with the same number of rows but
+    // different number of columns
+    let lhs = DMatrix::from_column_slice(2, 3, &[1., 2., 3., 4., 5., 6.]);
+    let rhs = DMatrix::from_column_slice(2, 2, &[7., 8., 9., 10.]);
+    let concat = DMatrix::from_column_slice(2, 5, &[1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]);
+    assert_relative_eq!(concat, concat_colwise(lhs, rhs));
+}
+
+#[test]
+// the same test as above but lhs is a fixed column size matrix
+fn matrix_concatenation_for_fixed_and_dyn_size_matrices() {
+    // two DMatrix instances with the same number of rows but
+    // different number of columns
+    let lhs = OMatrix::<f64, Dyn, U3>::from_column_slice(&[1., 2., 3., 4., 5., 6.]);
+    let rhs = DMatrix::from_column_slice(2, 2, &[7., 8., 9., 10.]);
+    let concat = DMatrix::from_column_slice(2, 5, &[1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]);
+    assert_relative_eq!(concat, concat_colwise(lhs, rhs));
+}
+
+#[test]
+// same test as above, but both matrices are fixed column size
+fn matrix_concatenation_for_fixed_size_matrices() {
+    // two DMatrix instances with the same number of rows but
+    // different number of columns
+    let lhs = OMatrix::<f64, U2, U3>::from_column_slice(&[1., 2., 3., 4., 5., 6.]);
+    let rhs = OMatrix::<f64, U2, U2>::from_column_slice(&[7., 8., 9., 10.]);
+    let concat =
+        OMatrix::<f64, U2, U5>::from_column_slice(&[1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]);
+    assert_relative_eq!(concat, concat_colwise(lhs, rhs));
 }

--- a/src/solvers/levmar/test.rs
+++ b/src/solvers/levmar/test.rs
@@ -4,7 +4,7 @@ use crate::test_helpers::differentiation::numerical_derivative;
 use crate::test_helpers::get_double_exponential_model_with_constant_offset;
 use approx::assert_relative_eq;
 use levenberg_marquardt::differentiate_numerically;
-use nalgebra::{DVector, U2, U5};
+use nalgebra::{DVector};
 
 // test that the jacobian of the least squares problem is correct if the parameter guesses
 // are correct. I observed that the numerical differentiation inside the levmar crate and my implementation

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -1,7 +1,7 @@
 use crate::{prelude::SeparableNonlinearModel, util::Weights};
 use nalgebra::{
-    allocator::Allocator, ComplexField, DVector, DefaultAllocator, Dim, DimAdd, Matrix, OMatrix,
-    OVector, RealField, Scalar,
+    allocator::Allocator, ComplexField, DefaultAllocator, Dim, DimAdd, Matrix, OMatrix, OVector,
+    RealField, Scalar,
 };
 use num_traits::{Float, FromPrimitive, Zero};
 use thiserror::Error as ThisError;

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -80,7 +80,7 @@ where
 {
     pub(crate) fn try_calculate(
         model: &Model,
-        data: OVector<Model::ScalarType, Model::OutputDim>,
+        data: &OVector<Model::ScalarType, Model::OutputDim>,
         weights: &Weights<Model::ScalarType, Model::OutputDim>,
         linear_coefficients: OVector<Model::ScalarType, Model::ModelDim>,
     ) -> Result<Self, Error<Model::Error>>

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -240,7 +240,6 @@ where
         let output_len = model.output_len().value();
         let weighted_residuals: OVector<_, _> =
             weighted_data - weights * model.eval()? * linear_coefficients;
-        println!("weighted_residuals: {}", weighted_residuals);
         let degrees_of_freedom =
             model.parameter_count().value() + model.base_function_count().value();
         if output_len <= degrees_of_freedom {
@@ -256,7 +255,6 @@ where
         let HTH_inv = (H.transpose() * H)
             .try_inverse()
             .ok_or(Error::MatrixInversionError)?;
-        println!("HTH_inv: {}", HTH_inv);
         let covariance_matrix = HTH_inv * sigma * sigma;
         let correlation_matrix = calc_correlation_matrix(&covariance_matrix);
 

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -1,6 +1,9 @@
-use nalgebra::{ComplexField, DefaultAllocator, Dim, DimAdd, OMatrix, OVector, Scalar};
+use crate::{prelude::SeparableNonlinearModel, util::Weights};
+use nalgebra::{ComplexField, DefaultAllocator, Dim, DimAdd, Matrix, OMatrix, OVector, Scalar};
+use num_traits::{Float, Zero};
 
-use crate::{prelude::SeparableNonlinearModel, util::weights::Weights};
+#[cfg(test)]
+mod test;
 
 /// this structure contains information about the goodness of
 /// a fit and some statistical properties like estimates uncerainties
@@ -64,6 +67,111 @@ where
         DefaultAllocator: nalgebra::allocator::Allocator<ScalarType, ModelDim>,
         DefaultAllocator: nalgebra::allocator::Allocator<ScalarType, Model::OutputDim, ModelDim>,
     {
+        // let hmat = weights
+        //     * model_function_jacobian(model, linear_coefficients.unwrap()).unwrap();
         todo!()
     }
+}
+
+// a helper function that calculates the jacobian of the
+// model function `$\vec{f}(\vec{\alpha},\vec{c})$` evaluated at the parameters `$(\vec{c},\vec{\alpha})$`
+// This is not the same as the jacobian of the
+// fitting problem, which is the jacobian `$\vec{f}(\vec{\alpha},\vec{c}(\vec{\alpha}))$`,
+// where `$\vec{c}(\vec{\alpha})$` is the linear coefficients that solve the linear problem.
+// see also the O'Leary matlab code.
+fn model_function_jacobian<Model>(
+    model: &Model,
+    c: OVector<Model::ScalarType, Model::ModelDim>,
+) -> Result<
+    OMatrix<
+        Model::ScalarType,
+        Model::OutputDim,
+        <Model::ModelDim as DimAdd<Model::ParameterDim>>::Output,
+    >,
+    Model::Error,
+>
+where
+    Model: SeparableNonlinearModel,
+    Model::ScalarType: Float + Zero + Scalar + ComplexField,
+    nalgebra::DefaultAllocator:
+        nalgebra::allocator::Allocator<Model::ScalarType, Model::ParameterDim>,
+    nalgebra::DefaultAllocator:
+        nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim, Model::ModelDim>,
+    nalgebra::DefaultAllocator:
+        nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim, Model::ParameterDim>,
+    nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<
+        Model::ScalarType,
+        Model::OutputDim,
+        <Model::ModelDim as DimAdd<Model::ParameterDim>>::Output,
+    >,
+    <Model as SeparableNonlinearModel>::ModelDim:
+        nalgebra::DimAdd<<Model as SeparableNonlinearModel>::ParameterDim>,
+    nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<
+        <Model as SeparableNonlinearModel>::ScalarType,
+        <Model as SeparableNonlinearModel>::ModelDim,
+    >,
+    nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<
+        <Model as SeparableNonlinearModel>::ScalarType,
+        <Model as SeparableNonlinearModel>::OutputDim,
+    >,
+{
+    // the part of the jacobian that contains the derivatives
+    // with respect to the nonlinear parameters
+    let mut jacobian_matrix_for_nonlinear_params =
+        OMatrix::<Model::ScalarType, Model::OutputDim, Model::ParameterDim>::zeros_generic(
+            model.output_len(),
+            model.parameter_count(),
+        );
+    for (idx, mut col) in jacobian_matrix_for_nonlinear_params
+        .column_iter_mut()
+        .enumerate()
+    {
+        col.copy_from(&(model.eval_partial_deriv(idx)? * &c));
+    }
+
+    Ok(concat_colwise(
+        model.eval()?,
+        jacobian_matrix_for_nonlinear_params,
+    ))
+}
+
+/// helper function to concatenate two matrices by pasting the
+/// columns after each other: [left,right]. The matrices must have
+/// the same number of rows.
+fn concat_colwise<T, R, C1, C2, S1, S2>(
+    left: Matrix<T, R, C1, S1>,
+    right: Matrix<T, R, C2, S2>,
+) -> OMatrix<T, R, <C1 as DimAdd<C2>>::Output>
+where
+    R: Dim,
+    C1: Dim + DimAdd<C2>,
+    C2: Dim,
+    T: Scalar + Zero,
+    nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<T, R, <C1 as DimAdd<C2>>::Output>,
+    nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<T, R, C1>,
+    nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<T, R, C2>,
+    S2: nalgebra::RawStorage<T, R, C2>,
+    S1: nalgebra::RawStorage<T, R, C1>,
+{
+    assert_eq!(
+        left.nrows(),
+        right.nrows(),
+        "left and right matrix must have the same number of rows"
+    );
+    let mut result = OMatrix::<T, R, <C1 as DimAdd<C2>>::Output>::zeros_generic(
+        R::from_usize(left.nrows()),
+        <C1 as DimAdd<C2>>::Output::from_usize(left.ncols() + right.ncols()),
+    );
+
+    for idx in 0..left.ncols() {
+        result.column_mut(idx).copy_from(&left.column(idx));
+    }
+
+    for idx in 0..right.ncols() {
+        result
+            .column_mut(idx + left.ncols())
+            .copy_from(&right.column(idx));
+    }
+
+    result
 }

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -24,7 +24,7 @@ where
     /// # References
     /// See [O'Leary and Rust 2012](https://www.nist.gov/publications/variable-projection-nonlinear-least-squares-problems)
     /// for reference.
-    pub covariance: OMatrix<
+    pub covariance_matrix: OMatrix<
         ScalarType,
         <ModelDim as DimAdd<ParameterDim>>::Output,
         <ModelDim as DimAdd<ParameterDim>>::Output,
@@ -34,3 +34,16 @@ where
     // /// used (and misused) measure of the quality of a regression.
     // pub r_squared: ScalarType,
 }
+
+// impl<ScalarType, ModelDim, ParameterDim> FitStatistics<ScalarType, ModelDim, ParameterDim>
+// where
+//     ModelDim: Dim + DimAdd<ParameterDim>,
+//     ParameterDim: Dim,
+//     DefaultAllocator: nalgebra::allocator::Allocator<
+//         ScalarType,
+//         <ModelDim as DimAdd<ParameterDim>>::Output,
+//         <ModelDim as DimAdd<ParameterDim>>::Output,
+//     >,
+// {
+//     pub(crate) fn try_calculate(model: &Model, weights: Weights, linear_coefficients: ()) {}
+// }

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -18,9 +18,9 @@ pub enum Error<ModelError: std::error::Error> {
     Underdetermined,
 }
 
-/// this structure contains information about the goodness of
-/// a fit and some statistical properties like estimates uncerainties
-/// of the parameters
+/// this structure contains some additional statistical information
+/// about the fit, such as errors on the parameters and other useful
+/// information to assess the quality of the fit.
 #[derive(Debug, Clone)]
 pub struct FitStatistics<Model>
 where
@@ -78,11 +78,13 @@ where
     >,
     nalgebra::DefaultAllocator: nalgebra::allocator::Allocator<Model::ScalarType, Model::OutputDim>,
 {
+    /// Calculate the fit statistics from the model, the data and the linear coefficients.
+    /// The given parameters must be the ones after the the fit has completed.
     pub(crate) fn try_calculate(
         model: &Model,
         data: &OVector<Model::ScalarType, Model::OutputDim>,
         weights: &Weights<Model::ScalarType, Model::OutputDim>,
-        linear_coefficients: OVector<Model::ScalarType, Model::ModelDim>,
+        linear_coefficients: &OVector<Model::ScalarType, Model::ModelDim>,
     ) -> Result<Self, Error<Model::Error>>
     where
         Model::ScalarType: Scalar + ComplexField + Float + Zero + FromPrimitive,

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -1,4 +1,6 @@
-use nalgebra::{DefaultAllocator, Dim, DimAdd, OMatrix};
+use nalgebra::{ComplexField, DefaultAllocator, Dim, DimAdd, OMatrix, OVector, Scalar};
+
+use crate::{prelude::SeparableNonlinearModel, util::weights::Weights};
 
 /// this structure contains information about the goodness of
 /// a fit and some statistical properties like estimates uncerainties
@@ -35,15 +37,33 @@ where
     // pub r_squared: ScalarType,
 }
 
-// impl<ScalarType, ModelDim, ParameterDim> FitStatistics<ScalarType, ModelDim, ParameterDim>
-// where
-//     ModelDim: Dim + DimAdd<ParameterDim>,
-//     ParameterDim: Dim,
-//     DefaultAllocator: nalgebra::allocator::Allocator<
-//         ScalarType,
-//         <ModelDim as DimAdd<ParameterDim>>::Output,
-//         <ModelDim as DimAdd<ParameterDim>>::Output,
-//     >,
-// {
-//     pub(crate) fn try_calculate(model: &Model, weights: Weights, linear_coefficients: ()) {}
-// }
+impl<ScalarType, ModelDim, ParameterDim> FitStatistics<ScalarType, ModelDim, ParameterDim>
+where
+    ModelDim: Dim + DimAdd<ParameterDim>,
+    ParameterDim: Dim,
+    DefaultAllocator: nalgebra::allocator::Allocator<
+        ScalarType,
+        <ModelDim as DimAdd<ParameterDim>>::Output,
+        <ModelDim as DimAdd<ParameterDim>>::Output,
+    >,
+{
+    pub(crate) fn try_calculate<Model>(
+        model: &Model,
+        weights: &Weights<ScalarType, Model::OutputDim>,
+        linear_coefficients: OVector<ScalarType, ModelDim>,
+    ) -> Option<Self>
+    where
+        ScalarType: Scalar + ComplexField,
+        Model: SeparableNonlinearModel<
+            ScalarType = ScalarType,
+            ModelDim = ModelDim,
+            ParameterDim = ParameterDim,
+        >,
+        DefaultAllocator: nalgebra::allocator::Allocator<ScalarType, Model::OutputDim>,
+        DefaultAllocator: nalgebra::allocator::Allocator<ScalarType, ParameterDim>,
+        DefaultAllocator: nalgebra::allocator::Allocator<ScalarType, ModelDim>,
+        DefaultAllocator: nalgebra::allocator::Allocator<ScalarType, Model::OutputDim, ModelDim>,
+    {
+        todo!()
+    }
+}

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -158,7 +158,7 @@ where
 
     /// the weighted residuals
     /// ```math
-    /// \vec{r_w}$ = W * (\vec{y} - \vec{f}(vec{\alpha},\vec{c}))
+    /// \vec{r_w} = W * (\vec{y} - \vec{f}(vec{\alpha},\vec{c}))
     /// ```
     /// at the best fit parameters.
     pub fn weighted_residuals(&self) -> &OVector<Model::ScalarType, Model::OutputDim> {

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -3,6 +3,7 @@ use nalgebra::{DefaultAllocator, Dim, DimAdd, OMatrix};
 /// this structure contains information about the goodness of
 /// a fit and some statistical properties like estimates uncerainties
 /// of the parameters
+#[derive(Debug, Clone)]
 pub struct FitStatistics<ScalarType, ModelDim, ParameterDim>
 where
     ModelDim: Dim + DimAdd<ParameterDim>,

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -51,7 +51,13 @@ where
         <Model::ModelDim as DimAdd<Model::ParameterDim>>::Output,
         <Model::ModelDim as DimAdd<Model::ParameterDim>>::Output,
     >,
+    /// the weighted residuals `$\vec{r_w}$ = W * (\vec{y} - \vec{f}(vec{\alpha},\vec{c}))$`,
+    /// where `$\vec{y}$` is the data, `$\vec{f}$` is the model function and `$W$` is the
+    /// weights
     pub weighted_residuals: OVector<Model::ScalarType, Model::OutputDim>,
+
+    /// the _weighted residual mean square_ or _regression standard error_.
+    pub sigma: Model::ScalarType,
     // /// The parameter `$R^2$`, also known as the coefficient of determination,
     // /// or the square of the multiple correlation coefficient. A commonly
     // /// used (and misused) measure of the quality of a regression.
@@ -106,7 +112,7 @@ where
             <Model as SeparableNonlinearModel>::OutputDim,
         >,
     {
-        let hmat = weights * model_function_jacobian(model, &linear_coefficients).unwrap();
+        let hmat = weights * model_function_jacobian(model, linear_coefficients).unwrap();
         let output_len = model.output_len().value();
         let weighted_residuals = weights * (data - model.eval().unwrap() * linear_coefficients);
         let degrees_of_freedom =
@@ -123,6 +129,7 @@ where
         Ok(Self {
             covariance_matrix,
             weighted_residuals,
+            sigma,
         })
     }
 }

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -182,10 +182,10 @@ where
         self.sigma.clone()
     }
 
-    /// helper function to extract the estimated standard deviation
+    /// helper function to extract the estimated _variance_
     /// of the nonlinear model parameters. Those could also be
     /// manually extracted from the diagonal of the covariance matrix.
-    pub fn stdev_nonlinear_parameters(&self) -> OVector<Model::ScalarType, Model::ParameterDim>
+    pub fn nonlinear_parameters_variance(&self) -> OVector<Model::ScalarType, Model::ParameterDim>
     where
         Model::ScalarType: Scalar + Zero,
         nalgebra::DefaultAllocator:
@@ -218,9 +218,9 @@ where
         )
     }
 
-    /// helper function to extract the estimated standard deviation
+    /// helper function to extract the estimated _variance_
     /// of the linear model parameters.
-    pub fn stdev_linear_parameters(&self) -> OVector<Model::ScalarType, Model::ModelDim>
+    pub fn linear_coefficients_variance(&self) -> OVector<Model::ScalarType, Model::ModelDim>
     where
         Model::ScalarType: Scalar + Zero,
         DefaultAllocator: Allocator<Model::ScalarType, Model::ModelDim>,

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -269,18 +269,6 @@ where
     }
 }
 
-/// generate a vector of ones with the given dimension
-fn vector_of_ones<ScalarType, D>(len: D) -> OVector<ScalarType, D>
-where
-    DefaultAllocator: Allocator<ScalarType, D>,
-    ScalarType: Scalar + Zero + num_traits::identities::One,
-    D: Dim,
-{
-    let mut v = OVector::<ScalarType, D>::zeros_generic(len, U1);
-    v.fill_with(|| ScalarType::one());
-    v
-}
-
 /// helper function to calculate a correlation matrix from a covariance matrix.
 /// See the O'Leary and Rust paper for reference.
 fn calc_correlation_matrix<ScalarType, D>(

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -31,7 +31,7 @@ pub(crate) enum Error<ModelError: std::error::Error> {
 /// about the fit, such as errors on the parameters and other useful
 /// information to assess the quality of the fit.
 ///
-/// # Where is R squared?
+/// # Where is `$R^2$`?
 ///
 /// We don't calculate `$R^2$` because "it is an inadequate measure for the
 /// goodness of the fit in nonlinear models" ([Spiess and Neumeyer 2010](https://doi.org/10.1186/1471-2210-10-6)).
@@ -130,9 +130,12 @@ where
     /// `$\vec{\alpha}=(\alpha_1,\alpha_2,\alpha_3)^T$`. Then the covariance matrix
     /// is odered for the parameter vector `$(c_1,c_2,\alpha_1,\alpha_2,\alpha_3)^T$`.
     /// The covariance matrix `$C$` (upper case C) is a square matrix of size `$5 \times 5$`.
-    /// Element `$C_{ij}$` is the covariance between the parameters `$i$` and `$j$`, so in this
-    /// example `$C_{11}$` is the variance of `$c_1$`, `$C_{12}$` is the covariance between `$c_1$`
-    /// and `$c_2$`, `$C_{13}$` is the covariance between `$c_1$` and `$\alpha_1$`, and so on.
+    /// Element `$C_{ij}$` is the covariance between the parameters at indices `$i$` and `$j$`, so in this
+    /// example:
+    /// * `$C_{11}$` is the variance of `$c_1$`,
+    /// * `$C_{12}$` is the covariance between `$c_1$`,
+    /// * and `$c_2$`, `$C_{13}$` is the covariance between `$c_1$` and `$\alpha_1$`,
+    /// * and so on.
     #[allow(clippy::type_complexity)]
     pub fn covariance_matrix(
         &self,
@@ -158,9 +161,9 @@ where
 
     /// the weighted residuals
     /// ```math
-    /// \vec{r_w} = W * (\vec{y} - \vec{f}(vec{\alpha},\vec{c}))
+    /// \vec{r_w} = W * (\vec{y} - \vec{f}(\vec{\alpha},\vec{c}))
     /// ```
-    /// at the best fit parameters.
+    /// at the best fit parameters `$\vec{alpha}$` and `$\vec{c}$`.
     pub fn weighted_residuals(&self) -> &OVector<Model::ScalarType, Model::OutputDim> {
         &self.weighted_residuals
     }
@@ -175,6 +178,13 @@ where
     /// of basis functions).
     pub fn regression_standard_error(&self) -> Model::ScalarType {
         self.sigma.clone()
+    }
+
+    /// helper function to extract the estimated standard deviation
+    /// of the nonlinear model parameters. Those could also be
+    /// manually extracted from the diagonal of the covariance matrix.
+    pub fn stdev_nonlinear_parameters(&self) -> OVector<Model::ScalarType, Model::ParameterDim> {
+        todo!()
     }
 }
 

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -3,7 +3,7 @@ use nalgebra::{DefaultAllocator, Dim, DimAdd, OMatrix};
 /// this structure contains information about the goodness of
 /// a fit and some statistical properties like estimates uncerainties
 /// of the parameters
-pub struct Statistics<ScalarType, ModelDim, ParameterDim>
+pub struct FitStatistics<ScalarType, ModelDim, ParameterDim>
 where
     ModelDim: Dim + DimAdd<ParameterDim>,
     ParameterDim: Dim,
@@ -28,8 +28,8 @@ where
         <ModelDim as DimAdd<ParameterDim>>::Output,
         <ModelDim as DimAdd<ParameterDim>>::Output,
     >,
-    /// The parameter `$R^2$`, also known as the coefficient of determination,
-    /// or the square of the multiple correlation coefficient. A commonly
-    /// used (and misused) measure of the quality of a regression.
-    pub r_squared: ScalarType,
+    // /// The parameter `$R^2$`, also known as the coefficient of determination,
+    // /// or the square of the multiple correlation coefficient. A commonly
+    // /// used (and misused) measure of the quality of a regression.
+    // pub r_squared: ScalarType,
 }

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -1,0 +1,35 @@
+use nalgebra::{DefaultAllocator, Dim, DimAdd, OMatrix};
+
+/// this structure contains information about the goodness of
+/// a fit and some statistical properties like estimates uncerainties
+/// of the parameters
+pub struct Statistics<ScalarType, ModelDim, ParameterDim>
+where
+    ModelDim: Dim + DimAdd<ParameterDim>,
+    ParameterDim: Dim,
+    DefaultAllocator: nalgebra::allocator::Allocator<
+        ScalarType,
+        <ModelDim as DimAdd<ParameterDim>>::Output,
+        <ModelDim as DimAdd<ParameterDim>>::Output,
+    >,
+{
+    /// The covariance matrix of the parameter estimates. The linear
+    /// parameters are ordered first, followed by the non-linear parameters
+    /// as if we had one big parameter vector `$(\vec{c}, \vec{\alpha})^T$`.
+    /// # Correlation
+    /// Note that we can calculate the estimated correlation matrix from
+    /// the covariance matrix by dividing each element `$c_{ij}$` by
+    /// `$\sqrt{c_{ii} c_{jj}}$`.
+    /// # References
+    /// See [O'Leary and Rust 2012](https://www.nist.gov/publications/variable-projection-nonlinear-least-squares-problems)
+    /// for reference.
+    pub covariance: OMatrix<
+        ScalarType,
+        <ModelDim as DimAdd<ParameterDim>>::Output,
+        <ModelDim as DimAdd<ParameterDim>>::Output,
+    >,
+    /// The parameter `$R^2$`, also known as the coefficient of determination,
+    /// or the square of the multiple correlation coefficient. A commonly
+    /// used (and misused) measure of the quality of a regression.
+    pub r_squared: ScalarType,
+}

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -1,7 +1,7 @@
 use crate::{prelude::SeparableNonlinearModel, util::Weights};
 use nalgebra::{
-    allocator::Allocator, ComplexField, DefaultAllocator, Dim, DimAdd, DimMin, DimSub, DimSum,
-    Matrix, OMatrix, OVector, RealField, Scalar, U0, U1,
+    allocator::Allocator, ComplexField, DefaultAllocator, Dim, DimAdd, DimMin, DimSub, Matrix,
+    OMatrix, OVector, RealField, Scalar, U0, U1,
 };
 use num_traits::{Float, FromPrimitive, Zero};
 use thiserror::Error as ThisError;

--- a/src/statistics/test.rs
+++ b/src/statistics/test.rs
@@ -1,12 +1,10 @@
 use std::convert::Infallible;
 
-use crate::{
-    model::SeparableModel, prelude::SeparableNonlinearModel, statistics::model_function_jacobian,
-};
+use crate::{prelude::SeparableNonlinearModel, statistics::model_function_jacobian};
 
 use super::{calc_correlation_matrix, concat_colwise};
 use approx::assert_relative_eq;
-use nalgebra::{matrix, DMatrix, DVector, Dim, Dyn, OMatrix, U2, U3, U5};
+use nalgebra::{DMatrix, DVector, Dim, Dyn, OMatrix, U2, U3, U5};
 #[test]
 fn matrix_concatenation_for_dynamic_matrices() {
     // two DMatrix instances with the same number of rows but

--- a/src/statistics/test.rs
+++ b/src/statistics/test.rs
@@ -1,6 +1,12 @@
+use std::convert::Infallible;
+
+use crate::{
+    model::SeparableModel, prelude::SeparableNonlinearModel, statistics::model_function_jacobian,
+};
+
 use super::{calc_correlation_matrix, concat_colwise};
 use approx::assert_relative_eq;
-use nalgebra::{DMatrix, Dyn, OMatrix, U2, U3, U5};
+use nalgebra::{matrix, DMatrix, DVector, Dim, Dyn, OMatrix, U2, U3, U5};
 #[test]
 fn matrix_concatenation_for_dynamic_matrices() {
     // two DMatrix instances with the same number of rows but
@@ -42,4 +48,74 @@ fn correlation_matrix_is_calculated_correctly_from_a_covariance_matrix() {
     let corr = DMatrix::from_row_slice(2, 2, &[1.0, 3. / f64::sqrt(10.), 4. / f64::sqrt(10.), 1.0]);
     let calc = calc_correlation_matrix(&cov);
     assert_relative_eq!(corr, calc);
+}
+
+/// this thing exists only to be evaluated and give us a jacobian
+struct DummyModel {}
+
+impl SeparableNonlinearModel for DummyModel {
+    type ScalarType = f64;
+    type Error = Infallible;
+    type ParameterDim = Dyn;
+    type ModelDim = Dyn;
+    type OutputDim = Dyn;
+
+    fn parameter_count(&self) -> Self::ParameterDim {
+        Dyn(2)
+    }
+
+    fn base_function_count(&self) -> Self::ModelDim {
+        Dyn(3)
+    }
+
+    fn output_len(&self) -> Self::OutputDim {
+        Dyn(3)
+    }
+
+    fn set_params(
+        &mut self,
+        _parameters: nalgebra::OVector<Self::ScalarType, Self::ParameterDim>,
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn params(&self) -> nalgebra::OVector<Self::ScalarType, Self::ParameterDim> {
+        todo!()
+    }
+
+    fn eval(
+        &self,
+    ) -> Result<OMatrix<Self::ScalarType, Self::OutputDim, Self::ModelDim>, Self::Error> {
+        Ok(DMatrix::from_row_slice(
+            3,
+            3,
+            &[1., 2., 3., 4., 5., 6., 7., 8., 9.],
+        ))
+    }
+
+    fn eval_partial_deriv(
+        &self,
+        derivative_index: usize,
+    ) -> Result<OMatrix<Self::ScalarType, Self::OutputDim, Self::ModelDim>, Self::Error> {
+        let mut jacobian = DMatrix::zeros(3, 3);
+        jacobian.column_mut(derivative_index).fill(1.0);
+        jacobian
+            .column_mut(self.base_function_count().value() - 1)
+            .fill(1.0);
+        Ok(jacobian)
+    }
+}
+
+#[test]
+fn model_function_jacobian_is_calculated_correctly() {
+    // this test makes sense once you look at the DummyModel implementation
+    // and print the matrices for the eval and the partial derivatives
+    let model = DummyModel {};
+    let c = DVector::from_column_slice(&[5., 6., 7.]);
+    let expected_jac = concat_colwise(
+        model.eval().unwrap(),
+        DMatrix::from_column_slice(3, 2, &[12., 12., 12., 13., 13., 13.]),
+    );
+    let calculated_jac = model_function_jacobian(&model, &c);
+    assert_relative_eq!(expected_jac, calculated_jac.unwrap());
 }

--- a/src/statistics/test.rs
+++ b/src/statistics/test.rs
@@ -1,0 +1,35 @@
+use super::concat_colwise;
+use approx::assert_relative_eq;
+use nalgebra::{DMatrix, Dyn, OMatrix, U2, U3, U5};
+#[test]
+fn matrix_concatenation_for_dynamic_matrices() {
+    // two DMatrix instances with the same number of rows but
+    // different number of columns
+    let lhs = DMatrix::from_column_slice(2, 3, &[1., 2., 3., 4., 5., 6.]);
+    let rhs = DMatrix::from_column_slice(2, 2, &[7., 8., 9., 10.]);
+    let concat = DMatrix::from_column_slice(2, 5, &[1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]);
+    assert_relative_eq!(concat, concat_colwise(lhs, rhs));
+}
+
+#[test]
+// the same test as above but lhs is a fixed column size matrix
+fn matrix_concatenation_for_fixed_and_dyn_size_matrices() {
+    // two DMatrix instances with the same number of rows but
+    // different number of columns
+    let lhs = OMatrix::<f64, Dyn, U3>::from_column_slice(&[1., 2., 3., 4., 5., 6.]);
+    let rhs = DMatrix::from_column_slice(2, 2, &[7., 8., 9., 10.]);
+    let concat = DMatrix::from_column_slice(2, 5, &[1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]);
+    assert_relative_eq!(concat, concat_colwise(lhs, rhs));
+}
+
+#[test]
+// same test as above, but both matrices are fixed column size
+fn matrix_concatenation_for_fixed_size_matrices() {
+    // two DMatrix instances with the same number of rows but
+    // different number of columns
+    let lhs = OMatrix::<f64, U2, U3>::from_column_slice(&[1., 2., 3., 4., 5., 6.]);
+    let rhs = OMatrix::<f64, U2, U2>::from_column_slice(&[7., 8., 9., 10.]);
+    let concat =
+        OMatrix::<f64, U2, U5>::from_column_slice(&[1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]);
+    assert_relative_eq!(concat, concat_colwise(lhs, rhs));
+}

--- a/src/statistics/test.rs
+++ b/src/statistics/test.rs
@@ -38,11 +38,8 @@ fn matrix_concatenation_for_fixed_size_matrices() {
 fn correlation_matrix_is_calculated_correctly_from_a_covariance_matrix() {
     // covariance matrix
     let cov = DMatrix::from_row_slice(2, 2, &[2., 3., 4., 5.]);
-    println!("cov: {}", cov);
     // correlation matrix
     let corr = DMatrix::from_row_slice(2, 2, &[1.0, 3. / f64::sqrt(10.), 4. / f64::sqrt(10.), 1.0]);
     let calc = calc_correlation_matrix(&cov);
-    println!("corr: {}", corr);
-    println!("calc: {}", calc);
     assert_relative_eq!(corr, calc);
 }

--- a/src/statistics/test.rs
+++ b/src/statistics/test.rs
@@ -1,4 +1,4 @@
-use super::concat_colwise;
+use super::{calc_correlation_matrix, concat_colwise};
 use approx::assert_relative_eq;
 use nalgebra::{DMatrix, Dyn, OMatrix, U2, U3, U5};
 #[test]
@@ -32,4 +32,17 @@ fn matrix_concatenation_for_fixed_size_matrices() {
     let concat =
         OMatrix::<f64, U2, U5>::from_column_slice(&[1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]);
     assert_relative_eq!(concat, concat_colwise(lhs, rhs));
+}
+
+#[test]
+fn correlation_matrix_is_calculated_correctly_from_a_covariance_matrix() {
+    // covariance matrix
+    let cov = DMatrix::from_row_slice(2, 2, &[2., 3., 4., 5.]);
+    println!("cov: {}", cov);
+    // correlation matrix
+    let corr = DMatrix::from_row_slice(2, 2, &[1.0, 3. / f64::sqrt(10.), 4. / f64::sqrt(10.), 1.0]);
+    let calc = calc_correlation_matrix(&cov);
+    println!("corr: {}", corr);
+    println!("calc: {}", calc);
+    assert_relative_eq!(corr, calc);
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(any(test, doctest))]
 mod test;
 
+pub mod weights;
+
 use nalgebra::{
     ClosedMul, ComplexField, DefaultAllocator, Dim, Matrix, OVector, RawStorageMut, Scalar,
 };

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -6,7 +6,8 @@ use nalgebra::{
 };
 use std::ops::Mul;
 
-pub mod weights;
+mod weights;
+pub use weights::Weights;
 
 /// A square diagonal matrix with dynamic dimension. Off-diagonal entries are assumed zero.
 /// This internally stores only the diagonal elements

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,12 +1,12 @@
 #[cfg(any(test, doctest))]
 mod test;
 
-pub mod weights;
-
 use nalgebra::{
     ClosedMul, ComplexField, DefaultAllocator, Dim, Matrix, OVector, RawStorageMut, Scalar,
 };
 use std::ops::Mul;
+
+pub mod weights;
 
 /// A square diagonal matrix with dynamic dimension. Off-diagonal entries are assumed zero.
 /// This internally stores only the diagonal elements

--- a/src/util/test.rs
+++ b/src/util/test.rs
@@ -1,4 +1,4 @@
-use crate::linalg_helpers::DiagMatrix;
+use crate::util::DiagMatrix;
 use approx::assert_relative_eq;
 use nalgebra::{ComplexField, DMatrix, DVector};
 

--- a/src/util/weights.rs
+++ b/src/util/weights.rs
@@ -1,4 +1,4 @@
-use crate::linalg_helpers::DiagMatrix;
+use crate::util::DiagMatrix;
 use nalgebra::{
     ClosedMul, ComplexField, DefaultAllocator, Dim, Matrix, OVector, RawStorageMut, Scalar,
 };
@@ -102,7 +102,7 @@ where
 
 #[cfg(any(test, doctest))]
 mod test {
-    use crate::solvers::levmar::weights::Weights;
+    use crate::util::weights::Weights;
     use nalgebra::{DMatrix, DVector};
 
     #[test]

--- a/tests/integration_tests/main.rs
+++ b/tests/integration_tests/main.rs
@@ -1,7 +1,7 @@
-use levenberg_marquardt::differentiate_numerically;
+
 use levenberg_marquardt::LevenbergMarquardt;
 use nalgebra::DVector;
-use nalgebra::DVectorSlice;
+
 use nalgebra::OVector;
 use nalgebra::Vector2;
 use nalgebra::Vector3;
@@ -18,7 +18,7 @@ use varpro::prelude::*;
 use varpro::solvers::levmar::*;
 
 use approx::assert_relative_eq;
-use std::time::Instant;
+
 
 #[test]
 // sanity check my calculations above
@@ -272,7 +272,7 @@ fn oleary_example_with_handrolled_model_produces_correct_results() {
     ]);
     // and finally the weights for the observations
     // these do actually influence the fits in the second decimal place
-    let w = DVector::from_vec(vec![1.0, 1.0, 1.0, 0.5, 0.5, 1.0, 0.5, 1.0, 0.5, 0.5]);
+    let _w = DVector::from_vec(vec![1.0, 1.0, 1.0, 0.5, 0.5, 1.0, 0.5, 1.0, 0.5, 0.5]);
 
     let model = OLearyExampleModel::new(t, initial_guess);
     let problem = LevMarProblemBuilder::new(model)
@@ -281,22 +281,22 @@ fn oleary_example_with_handrolled_model_produces_correct_results() {
         .build()
         .unwrap();
 
-    let p2 = problem.clone();
+    let _p2 = problem.clone();
 
     let (problem, report) = LevMarSolver::new().minimize(problem);
     assert!(
         report.termination.was_successful(),
         "fitting did not terminate successfully"
     );
-    let alpha_fit = problem.params();
-    let c_fit = problem
+    let _alpha_fit = problem.params();
+    let _c_fit = problem
         .linear_coefficients()
         .expect("solved problem must have linear coefficients");
     // solved parameters from the matlab code
     // they note that many parameters fit the observations well
-    let alpha_true =
+    let _alpha_true =
         OVector::<f64, U3>::from_vec(vec![1.0132255e+00, 2.4968675e+00, 4.0625148e+00]);
-    let c_true = OVector::<f64, U2>::from_vec(vec![5.8416357e+00, 1.1436854e+00]);
+    let _c_true = OVector::<f64, U2>::from_vec(vec![5.8416357e+00, 1.1436854e+00]);
     // @todo comment this in again
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!
     // !!!!!!!!!!!!!!!!!!!!!!!

--- a/tests/integration_tests/main.rs
+++ b/tests/integration_tests/main.rs
@@ -303,12 +303,12 @@ fn oleary_example_with_handrolled_model_produces_correct_results() {
     // assert_relative_eq!(alpha_fit, alpha_true, epsilon = 1e-5);
     // assert_relative_eq!(c_fit, c_true, epsilon = 1e-5);
 
-    let (mut problem, report) = LevMarSolver::new().fit_with_statistics(p2);
-    println!("cov mat = {}", report.covariance_matrix);
+    // let (mut problem, report) = LevMarSolver::new().fit_with_statistics(p2);
+    // println!("cov mat = {}", report.covariance_matrix);
 
-    println!("jacobian analytical= {}", problem.jacobian().unwrap());
-    let jacobian_analytical = problem.jacobian().unwrap();
-    let jacobian_numerical = differentiate_numerically(&mut problem).unwrap();
-    println!("jacobian numerical= {}", jacobian_numerical);
-    assert_relative_eq!(jacobian_analytical, jacobian_numerical, epsilon = 1e-4);
+    // println!("jacobian analytical= {}", problem.jacobian().unwrap());
+    // let jacobian_analytical = problem.jacobian().unwrap();
+    // let jacobian_numerical = differentiate_numerically(&mut problem).unwrap();
+    // println!("jacobian numerical= {}", jacobian_numerical);
+    // assert_relative_eq!(jacobian_analytical, jacobian_numerical, epsilon = 1e-4);
 }

--- a/tests/integration_tests/main.rs
+++ b/tests/integration_tests/main.rs
@@ -303,7 +303,7 @@ fn oleary_example_with_handrolled_model_produces_correct_results() {
     // assert_relative_eq!(alpha_fit, alpha_true, epsilon = 1e-5);
     // assert_relative_eq!(c_fit, c_true, epsilon = 1e-5);
 
-    let (mut problem, report) = LevMarSolver::new().minimize_with_statistics(p2);
+    let (mut problem, report) = LevMarSolver::new().fit_with_statistics(p2);
     println!("cov mat = {}", report.covariance);
 
     println!("jacobian analytical= {}", problem.jacobian().unwrap());

--- a/tests/integration_tests/main.rs
+++ b/tests/integration_tests/main.rs
@@ -1,3 +1,4 @@
+use levenberg_marquardt::LevenbergMarquardt;
 use nalgebra::DVector;
 use nalgebra::OVector;
 use nalgebra::Vector2;
@@ -222,7 +223,7 @@ fn double_exponential_fitting_without_noise_produces_accurate_results_with_leven
         &y,
     );
 
-    let (levenberg_marquardt_solution, report) = LevMarSolver::new()
+    let (levenberg_marquardt_solution, report) = LevenbergMarquardt::new()
         // if I don't set this, the solver will not converge
         .with_stepbound(1.)
         .minimize(levenberg_marquart_problem);

--- a/tests/integration_tests/main.rs
+++ b/tests/integration_tests/main.rs
@@ -2,6 +2,7 @@ use levenberg_marquardt::LevenbergMarquardt;
 use nalgebra::DMatrix;
 use nalgebra::DVector;
 
+use nalgebra::vector;
 use nalgebra::OVector;
 use nalgebra::Vector2;
 use nalgebra::Vector3;
@@ -351,6 +352,17 @@ fn oleary_example_with_handrolled_model_produces_correct_results() {
         epsilon = 1e-5,
     );
 
+    assert_relative_eq!(
+        statistics.nonlinear_parameters_variance(),
+        vector![2.6925e-04, 8.5784e-05, 8.2272e-04],
+        epsilon = 1e-5,
+    );
+    assert_relative_eq!(
+        statistics.linear_coefficients_variance(),
+        vector![4.4887e-03, 4.3803e-03],
+        epsilon = 1e-5,
+    );
+
     let expected_correlation_matrix = nalgebra::matrix![
      1.0000,  -0.9993,  -0.1966,  -0.7571,  -0.9914;
     -0.9993,   1.0000,   0.1942,   0.7695,   0.9918;
@@ -471,6 +483,17 @@ fn test_oleary_example_with_separable_model() {
     assert_relative_eq!(
         statistics.covariance_matrix(),
         &expected_covariance_matrix,
+        epsilon = 1e-5,
+    );
+
+    assert_relative_eq!(
+        statistics.nonlinear_parameters_variance(),
+        DVector::from_row_slice(&[2.6925e-04, 8.5784e-05, 8.2272e-04]),
+        epsilon = 1e-5,
+    );
+    assert_relative_eq!(
+        statistics.linear_coefficients_variance(),
+        DVector::from_row_slice(&[4.4887e-03, 4.3803e-03]),
         epsilon = 1e-5,
     );
 

--- a/tests/integration_tests/main.rs
+++ b/tests/integration_tests/main.rs
@@ -304,7 +304,7 @@ fn oleary_example_with_handrolled_model_produces_correct_results() {
     // assert_relative_eq!(c_fit, c_true, epsilon = 1e-5);
 
     let (mut problem, report) = LevMarSolver::new().fit_with_statistics(p2);
-    println!("cov mat = {}", report.covariance);
+    println!("cov mat = {}", report.covariance_matrix);
 
     println!("jacobian analytical= {}", problem.jacobian().unwrap());
     let jacobian_analytical = problem.jacobian().unwrap();

--- a/tests/integration_tests/main.rs
+++ b/tests/integration_tests/main.rs
@@ -71,6 +71,7 @@ fn double_exponential_fitting_without_noise_produces_accurate_results() {
         .observations(y)
         .build()
         .expect("Building valid problem should not panic");
+    _ = format!("{:?}", problem);
 
     let (fit_result, statistics) = LevMarSolver::new()
         .fit_with_statistics(problem)

--- a/tests/integration_tests/main.rs
+++ b/tests/integration_tests/main.rs
@@ -1,4 +1,3 @@
-
 use levenberg_marquardt::LevenbergMarquardt;
 use nalgebra::DVector;
 
@@ -18,7 +17,6 @@ use varpro::prelude::*;
 use varpro::solvers::levmar::*;
 
 use approx::assert_relative_eq;
-
 
 #[test]
 // sanity check my calculations above
@@ -70,29 +68,29 @@ fn double_exponential_fitting_without_noise_produces_accurate_results() {
         .build()
         .expect("Building valid problem should not panic");
 
-    let (problem, report) = LevMarSolver::new().minimize(problem);
+    let result = LevMarSolver::new()
+        .fit(problem)
+        .expect("fit must complete succesfully");
     assert!(
-        report.termination.was_successful(),
+        result.minimization_report.termination.was_successful(),
         "Levenberg Marquardt did not converge"
     );
 
     // extract the calculated paramters, because tau1 and tau2 might switch places here
-    let (tau1_index, tau2_index) = if problem.params()[0] < problem.params()[1] {
-        (0usize, 1usize)
-    } else {
-        (1, 0)
-    };
-    let tau1_calc = problem.params()[tau1_index];
-    let tau2_calc = problem.params()[tau2_index];
-    let c1_calc = problem
+    let (tau1_index, tau2_index) =
+        if result.nonlinear_parameters()[0] < result.nonlinear_parameters()[1] {
+            (0usize, 1usize)
+        } else {
+            (1, 0)
+        };
+    let tau1_calc = result.nonlinear_parameters()[tau1_index];
+    let tau2_calc = result.nonlinear_parameters()[tau2_index];
+    let c = result
         .linear_coefficients()
-        .expect("linear coeffs must exist")[tau1_index];
-    let c2_calc = problem
-        .linear_coefficients()
-        .expect("linear coeffs must exist")[tau2_index];
-    let c3_calc = problem
-        .linear_coefficients()
-        .expect("linear coeffs must exist")[2];
+        .expect("linear coeffs must exist");
+    let c1_calc = c[tau1_index];
+    let c2_calc = c[tau2_index];
+    let c3_calc = c[2];
 
     // assert that the calculated coefficients and nonlinear model parameters are correct
     assert_relative_eq!(c1, c1_calc, epsilon = 1e-8);
@@ -100,10 +98,6 @@ fn double_exponential_fitting_without_noise_produces_accurate_results() {
     assert_relative_eq!(c3, c3_calc, epsilon = 1e-8);
     assert_relative_eq!(tau1, tau1_calc, epsilon = 1e-8);
     assert_relative_eq!(tau2, tau2_calc, epsilon = 1e-8);
-    assert!(
-        report.termination.was_successful(),
-        "Termination not successful"
-    );
 }
 
 #[test]
@@ -135,25 +129,25 @@ fn double_exponential_fitting_without_noise_produces_accurate_results_with_handr
         .build()
         .expect("Building valid problem should not panic");
 
-    let (problem, report) = LevMarSolver::new().minimize(problem);
+    let result = LevMarSolver::new()
+        .fit(problem)
+        .expect("fitting must exit succesfully");
 
     // extract the calculated paramters, because tau1 and tau2 might switch places here
-    let (tau1_index, tau2_index) = if problem.params()[0] < problem.params()[1] {
-        (0usize, 1usize)
-    } else {
-        (1, 0)
-    };
-    let tau1_calc = problem.params()[tau1_index];
-    let tau2_calc = problem.params()[tau2_index];
-    let c1_calc = problem
+    let (tau1_index, tau2_index) =
+        if result.nonlinear_parameters()[0] < result.nonlinear_parameters()[1] {
+            (0usize, 1usize)
+        } else {
+            (1, 0)
+        };
+    let tau1_calc = result.nonlinear_parameters()[tau1_index];
+    let tau2_calc = result.nonlinear_parameters()[tau2_index];
+    let c = result
         .linear_coefficients()
-        .expect("linear coeffs must exist")[tau1_index];
-    let c2_calc = problem
-        .linear_coefficients()
-        .expect("linear coeffs must exist")[tau2_index];
-    let c3_calc = problem
-        .linear_coefficients()
-        .expect("linear coeffs must exist")[2];
+        .expect("linear coeffs must exist");
+    let c1_calc = c[tau1_index];
+    let c2_calc = c[tau2_index];
+    let c3_calc = c[2];
 
     // assert that the calculated coefficients and nonlinear model parameters are correct
     assert_relative_eq!(c1, c1_calc, epsilon = 1e-8);
@@ -163,7 +157,7 @@ fn double_exponential_fitting_without_noise_produces_accurate_results_with_handr
     assert_relative_eq!(tau2, tau2_calc, epsilon = 1e-8);
 
     assert!(
-        report.termination.was_successful(),
+        result.minimization_report.termination.was_successful(),
         "Termination not successful"
     );
 }


### PR DESCRIPTION
- Deprecate the `minimize` function of the LevMarSolver and
replace it with `fit`, with a slightly different API.
- Add a function `fit_with_statistics` and a `statistics` module
that calculates additional statistical information about the fit 
(if successful). It allows us to extract the estimated standard
errors of the model parameters (both linear and nonlinear) but also
provides more complete information like the covariance matrix and
the correlation matrix.
- add more exhaustive tests 
- add original varpro matlab code from DP O'Leary and BW Rust
with permission
- bump benchmarking dependencies