### PR TITLE
Feature/remove typestate pattern from model builder

### DIFF
--- a/src/model/builder/error.rs
+++ b/src/model/builder/error.rs
@@ -108,4 +108,8 @@ pub enum ModelBuildError {
     #[error("Missing initial guesses for model parameters")]
     /// missing initial guesses for parameters
     MissingInitialParameters,
+
+    #[error("Illegal call to 'partial_deriv': a call to this function can only follow a call to 'function' or another call to 'partial_deriv'")]
+    /// an illegal call to the partial_deriv function
+    IllegalCallToPartialDeriv,
 }

--- a/src/model/builder/mod.rs
+++ b/src/model/builder/mod.rs
@@ -253,20 +253,28 @@ pub enum SeparableModelBuilder<ScalarType>
 where
     ScalarType: Scalar,
 {
+    #[doc(hidden)]
     /// builder is in an error state
     Error(ModelBuildError),
     /// builder is in normal state (i.e. NOT in the process of building a function)
+    #[doc(hidden)]
     Normal(UnfinishedModel<ScalarType>),
     /// builder is in the state of building a function
+    #[doc(hidden)]
     FunctionBuilding {
+        /// the currently held model
         model: UnfinishedModel<ScalarType>,
+        /// the function we are currently building. It is added
+        /// to the model once a builder function is called that
+        /// indicates that building this function is over
         function_builder: ModelBasisFunctionBuilder<ScalarType>,
     },
 }
 
 /// a helper structure that represents an unfinished separable model
 #[derive(Default)]
-struct UnfinishedModel<ScalarType: Scalar> {
+#[doc(hidden)]
+pub struct UnfinishedModel<ScalarType: Scalar> {
     /// the parameter names
     parameter_names: Vec<String>,
     /// the base functions
@@ -355,7 +363,7 @@ where
     /// # Usage
     /// For usage see the documentation of the [SeparableModelBuilder](crate::model::builder::SeparableModelBuilder)
     /// struct documentation.
-    pub fn invariant_function<F>(mut self, function: F) -> Self
+    pub fn invariant_function<F>(self, function: F) -> Self
     where
         F: Fn(&DVector<ScalarType>) -> DVector<ScalarType> + 'static,
     {

--- a/src/model/builder/mod.rs
+++ b/src/model/builder/mod.rs
@@ -396,13 +396,61 @@ where
         StrCollection: IntoIterator,
         StrCollection::Item: AsRef<str>,
     {
-        SeparableModelBuilderProxyWithDerivatives::new(self.model_result, function_params, function)
+        match self {
+            SeparableModelBuilder::Error(err) => Self::from(err),
+            SeparableModelBuilder::Normal(model) => {
+                let function_builder = ModelBasisFunctionBuilder::new(
+                    model.parameter_names.clone(),
+                    function_params,
+                    function,
+                );
+                Self::FunctionBuilding {
+                    model,
+                    function_builder,
+                }
+            }
+            SeparableModelBuilder::FunctionBuilding {
+                model,
+                function_builder,
+            } => Self::from(extend_model(model, function_builder))
+                .function(function_params, function),
+        }
+    }
+
+    /// Add a partial derivative to a function, see the example in the documentation
+    /// to this structure.
+    /// A call to this function must only occur when it follows a call to
+    /// `function` or another call to `partial_derivative`. Other cases will
+    /// lead to errors when building the model.
+    pub fn partial_deriv<StrType: AsRef<str>, F, ArgList>(
+        self,
+        parameter: StrType,
+        derivative: F,
+    ) -> Self
+    where
+        F: BasisFunction<ScalarType, ArgList> + 'static,
+    {
+        match self {
+            SeparableModelBuilder::Error(err) => Self::from(err),
+            SeparableModelBuilder::Normal(_model) => {
+                // only when we are in the process of building a function, may
+                // we call this function
+                Self::from(Err(ModelBuildError::IllegalCallToPartialDeriv))
+            }
+            SeparableModelBuilder::FunctionBuilding {
+                model,
+                function_builder,
+            } => Self::FunctionBuilding {
+                model,
+                function_builder: function_builder.partial_deriv(parameter.as_ref(), derivative),
+            },
+        }
     }
 
     /// Set the independent variable `$x$` which will be used when evaluating the model.
     /// Also see the struct documentation of [SeparableModelBuilder](crate::model::builder::SeparableModelBuilder)
     /// for information on how to use this method.
-    pub fn independent_variable(mut self, x: DVector<ScalarType>) -> Self {
+    pub fn independent_variable(self, x: DVector<ScalarType>) -> Self {
         match self {
             SeparableModelBuilder::Error(err) => Self::from(err),
             SeparableModelBuilder::Normal(mut model) => {
@@ -419,7 +467,7 @@ where
     /// Set the initial values for the model parameters `$\vec{\alpha}$`.
     /// Also see the struct documentation of [SeparableModelBuilder](crate::model::builder::SeparableModelBuilder)
     /// for information on how to use this method.
-    pub fn initial_parameters(mut self, initial_parameters: Vec<ScalarType>) -> Self {
+    pub fn initial_parameters(self, initial_parameters: Vec<ScalarType>) -> Self {
         match self {
             SeparableModelBuilder::Error(err) => Self::from(err),
             SeparableModelBuilder::Normal(mut model) => {
@@ -510,202 +558,6 @@ impl<ScalarType: Scalar> TryInto<SeparableModel<ScalarType>> for UnfinishedModel
                 x_vector,
                 current_parameters: DVector::from_vec(initial_parameters),
             })
-        }
-    }
-}
-/// helper struct that contains a seperable model as well as a model function builder
-/// used inside the SeparableModelBuilderProxyWithDerivatives.
-struct ModelAndModelBasisFunctionBuilderPair<ScalarType>
-where
-    ScalarType: Scalar,
-{
-    model: UnfinishedModel<ScalarType>,
-    builder: ModelBasisFunctionBuilder<ScalarType>,
-}
-
-impl<ScalarType> ModelAndModelBasisFunctionBuilderPair<ScalarType>
-where
-    ScalarType: Scalar,
-{
-    fn new(
-        model: UnfinishedModel<ScalarType>,
-        builder: ModelBasisFunctionBuilder<ScalarType>,
-    ) -> Self {
-        Self { model, builder }
-    }
-}
-
-/// This is just a proxy that does need to be used directly. For constructing a model from
-/// a builder see the documentation for [SeparableModelBuilder](self::SeparableModelBuilder).
-/// **Sidenote** This structure will hopefully be made more elegant using some metaprogramming techniques
-/// in the future. Right now this exists to make sure that partial derivatives cannot accidentally
-/// be added to invariant functions. The compiler simply will forbid it. In future the library aims
-/// to make more such checks at compile time and reduce the need for runtime errors caused by invalid model
-/// construction.
-#[must_use = "This is meant as a transient expression proxy. Use build() to build a model."]
-pub struct SeparableModelBuilderProxyWithDerivatives<ScalarType>
-where
-    ScalarType: Scalar,
-{
-    current_result: Result<ModelAndModelBasisFunctionBuilderPair<ScalarType>, ModelBuildError>,
-}
-
-impl<ScalarType> From<ModelBuildError> for SeparableModelBuilderProxyWithDerivatives<ScalarType>
-where
-    ScalarType: Scalar,
-{
-    fn from(err: ModelBuildError) -> Self {
-        Self {
-            current_result: Err(err),
-        }
-    }
-}
-
-impl<ScalarType> SeparableModelBuilderProxyWithDerivatives<ScalarType>
-where
-    ScalarType: Scalar,
-{
-    /// Construct an instance. This is invoked when adding a function that depends on model
-    /// parameters to the [SeparableModelBuilder](self::SeparableModelBuilder)
-    /// # Arguments
-    /// * `model_result`: the current model or an error
-    /// * `function_parameters`: the given list of nonlinear function parameters
-    /// * `function`: the function
-    fn new<F, StrCollection, ArgList>(
-        model_result: Result<UnfinishedModel<ScalarType>, ModelBuildError>,
-        function_parameters: StrCollection,
-        function: F,
-    ) -> Self
-    where
-        F: BasisFunction<ScalarType, ArgList> + 'static,
-        StrCollection: IntoIterator,
-        StrCollection::Item: AsRef<str>,
-    {
-        match model_result {
-            Ok(model) => {
-                let model_parameters = model.parameter_names.clone();
-                Self {
-                    current_result: Ok(ModelAndModelBasisFunctionBuilderPair::new(
-                        model,
-                        ModelBasisFunctionBuilder::new(
-                            model_parameters,
-                            function_parameters,
-                            function,
-                        ),
-                    )),
-                }
-            }
-            Err(err) => Self {
-                current_result: Err(err),
-            },
-        }
-    }
-
-    /// Add a partial derivative to a function. This function is documented as part of the
-    /// [SeparableModelBuilder](self::SeparableModelBuilder) documentation.
-    /// *Info*: the reason it appears in this proxy only is to make sure that partial derivatives
-    /// can only be added to functions that depend on model parameters.
-    pub fn partial_deriv<StrType: AsRef<str>, F, ArgList>(
-        self,
-        parameter: StrType,
-        derivative: F,
-    ) -> Self
-    where
-        F: BasisFunction<ScalarType, ArgList> + 'static,
-    {
-        match self.current_result {
-            Ok(result) => Self {
-                current_result: Ok(ModelAndModelBasisFunctionBuilderPair {
-                    model: result.model,
-                    builder: result.builder.partial_deriv(parameter.as_ref(), derivative),
-                }),
-            },
-            Err(err) => Self::from(err),
-        }
-    }
-
-    /// Add a function `\vec{f}(\vec{x})` that does not depend on the model parameters. This is documented
-    /// as part of the [SeparableModelBuilder](self::SeparableModelBuilder) documentation.
-    pub fn invariant_function<F>(self, function: F) -> SeparableModelBuilder<ScalarType>
-    where
-        F: Fn(&DVector<ScalarType>) -> DVector<ScalarType> + 'static,
-    {
-        match self.current_result {
-            Ok(pair) => {
-                let model_result = extend_model(pair.model, pair.builder);
-                SeparableModelBuilder::from(model_result).invariant_function(function)
-            }
-            Err(err) => SeparableModelBuilder::from(err),
-        }
-    }
-
-    /// Add a function `\vec{f}(\vec{x},\alpha_j,...,\alpha_k)` that depends on a subset of the
-    /// model parameters. This functionality is documented as part of the [SeparableModelBuilder](self::SeparableModelBuilder)
-    /// documentation.
-    pub fn function<F, StrCollection, ArgList>(
-        self,
-        function_params: StrCollection,
-        function: F,
-    ) -> SeparableModelBuilderProxyWithDerivatives<ScalarType>
-    where
-        F: BasisFunction<ScalarType, ArgList> + 'static,
-        StrCollection: IntoIterator,
-        StrCollection::Item: AsRef<str>,
-    {
-        match self.current_result {
-            Ok(pair) => {
-                let model_result = extend_model(pair.model, pair.builder);
-                Self::new(model_result, function_params, function)
-            }
-            Err(err) => SeparableModelBuilderProxyWithDerivatives::from(err),
-        }
-    }
-
-    /// Set the independent variable `\vec{x}`
-    ///
-    /// # Usage
-    /// For usage see the documentation of the [SeparableModelBuilder](crate::model::builder::SeparableModelBuilder)
-    /// struct documentation.
-    pub fn independent_variable(self, x: DVector<ScalarType>) -> SeparableModelBuilder<ScalarType> {
-        match self.current_result {
-            Ok(pair) => {
-                let model_result = extend_model(pair.model, pair.builder);
-                SeparableModelBuilder::from(model_result).independent_variable(x)
-            }
-            Err(err) => SeparableModelBuilder::from(err),
-        }
-    }
-
-    /// Set the initial value for the nonlinear parameters `\vec{\alpha}`
-    ///
-    /// # Usage
-    /// For usage see the documentation of the [SeparableModelBuilder](crate::model::builder::SeparableModelBuilder)
-    /// struct documentation.
-    pub fn initial_parameters(
-        self,
-        initial_parameters: Vec<ScalarType>,
-    ) -> SeparableModelBuilder<ScalarType> {
-        match self.current_result {
-            Ok(pair) => {
-                let model_result = extend_model(pair.model, pair.builder);
-                SeparableModelBuilder::from(model_result).initial_parameters(initial_parameters)
-            }
-            Err(err) => SeparableModelBuilder::from(err),
-        }
-    }
-
-    /// Finalized the building process and build a separable model.
-    /// This functionality is documented as part of the [SeparableModelBuilder](self::SeparableModelBuilder)
-    /// documentation.
-    pub fn build(self) -> Result<SeparableModel<ScalarType>, ModelBuildError> {
-        // this method converts the internal results into a separable model and uses its
-        // facilities to check for completion and the like
-        match self.current_result {
-            Ok(pair) => {
-                let model_result = extend_model(pair.model, pair.builder);
-                SeparableModelBuilder::from(model_result).build()
-            }
-            Err(err) => SeparableModelBuilder::from(err).build(),
         }
     }
 }

--- a/src/model/builder/modelfunction_builder/mod.rs
+++ b/src/model/builder/modelfunction_builder/mod.rs
@@ -19,7 +19,7 @@ use crate::model::model_basis_function::ModelBasisFunction;
 /// (all other derivatives are zero, because the function does not depends on other params)
 ///
 #[doc(hidden)]
-pub(crate) struct ModelBasisFunctionBuilder<ScalarType>
+pub struct ModelBasisFunctionBuilder<ScalarType>
 where
     ScalarType: Scalar,
 {

--- a/src/model/model_basis_function.rs
+++ b/src/model/model_basis_function.rs
@@ -13,7 +13,8 @@ type BaseFuncType<ScalarType> =
 
 /// An internal type that is used to store basefunctions whose interface has been wrapped in
 /// such a way that they can accept the location and the *complete model parameters as arguments*.
-pub(crate) struct ModelBasisFunction<ScalarType>
+#[doc(hidden)]
+pub struct ModelBasisFunction<ScalarType>
 where
     ScalarType: Scalar,
 {


### PR DESCRIPTION
remove the typestate pattern that made things more complicated. Related to the comments I made in [this issue](https://github.com/geo-ant/varpro/issues/28).