### PR TITLE
make ci jobs run once a month

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main, dev ]
+  schedule:
+  # Runs the workflow at 00:00 on the first day of every month
+  - cron: '0 0 1 * *'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main, dev]
+  schedule:
+  # Runs the workflow at 00:00 on the first day of every month
+  - cron: '0 0 1 * *'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main, dev ]
+  schedule:
+  # Runs the workflow at 00:00 on the first day of every month
+  - cron: '0 0 1 * *'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
ci jobs now run once a month (or more if we do PRs or pushes to main). This keeps the badges up to date.